### PR TITLE
add linux tests

### DIFF
--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -12,10 +12,11 @@ on:
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/scheduled_test.yml
+++ b/.github/workflows/scheduled_test.yml
@@ -10,10 +10,11 @@ on:
 jobs:
   build:
 
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     install_requires=[
         "numpy",
         "pandas",
-        "mikeio >= 0.6",
+        "mikeio >= 0.7",
         "matplotlib",
         "xarray",
         "markdown",
@@ -28,13 +28,7 @@ setuptools.setup(
             "shapely",
             "plotly >= 4.5",
         ],
-        "test": [
-            "pytest",
-            "shapely",
-            "netCDF4",
-            "openpyxl",
-            "dask",
-        ],
+        "test": ["pytest", "shapely", "netCDF4", "openpyxl", "dask",],
     },
     entry_points="""
         [console_scripts]
@@ -59,7 +53,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
-        "Operating System :: Microsoft :: Windows",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Scientific/Engineering",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setuptools.setup(
     author="Jesper Sandvig Mariegaard",
     author_email="jem@dhigroup.com",
     description="Compare results from MIKE FM simulations with observations.",
-    platform="windows_x64",
     license="MIT",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_modelresult.py
+++ b/tests/test_modelresult.py
@@ -39,7 +39,7 @@ def Hm0_HKNA():
 
 @pytest.fixture
 def wind_HKNA():
-    fn = "tests/testdata/SW/HKNA_Wind.dfs0"
+    fn = "tests/testdata/SW/HKNA_wind.dfs0"
     return PointObservation(fn, item=0, x=4.2420, y=52.6887, name="HKNA")
 
 


### PR DESCRIPTION
mikeio 0.7 have been released. This means that fmskill now runs on linux and python 3.9. We need to test this in our CI.