### PR TITLE
Show scatter points sample

### DIFF
--- a/fmskill/comparison.py
+++ b/fmskill/comparison.py
@@ -164,24 +164,24 @@ class BaseComparer:
         self._obs_names: List[str]
         self._mod_names: List[str]
         self._mod_colors = [
-            "#1f78b4", 
-            "#33a02c", 
-            "#ff7f00", 
-            "#93509E", 
-            "#63CEFF", 
-            "#fdbf6f", 
-            "#004165", 
-            "#8B8D8E", 
-            "#0098DB", 
-            "#61C250", 
-            "#a6cee3", 
-            "#b2df8a", 
-            "#fb9a99", 
-            "#cab2d6", 
-            "#003f5c", 
-            "#2f4b7c", 
-            "#665191", 
-            "#e31a1c", 
+            "#1f78b4",
+            "#33a02c",
+            "#ff7f00",
+            "#93509E",
+            "#63CEFF",
+            "#fdbf6f",
+            "#004165",
+            "#8B8D8E",
+            "#0098DB",
+            "#61C250",
+            "#a6cee3",
+            "#b2df8a",
+            "#fb9a99",
+            "#cab2d6",
+            "#003f5c",
+            "#2f4b7c",
+            "#665191",
+            "#e31a1c",
         ]
 
         self._resi_color = "#8B8D8E"
@@ -815,7 +815,7 @@ class BaseComparer:
         *,
         binsize: float = None,
         nbins: int = 20,
-        show_points: bool = None,
+        show_points: Union[bool, int, str] = None,
         show_hist: bool = True,
         backend: str = "matplotlib",
         figsize: List[float] = (8, 8),
@@ -843,9 +843,11 @@ class BaseComparer:
             the size of each bin in the 2d histogram, by default None
         nbins : int, optional
             number of bins (if binsize is not given), by default 20
-        show_points : bool, optional
+        show_points : (bool, int, str), optional
             Should the scatter points be displayed?
-            None means: only show points if fewer than threshold, by default None
+            None means: only show points if fewer than threshold, by default None.
+            'sample': will display a random sample of 10,000 points.
+            int: if 'n' (int) given, then 'n' points will be displayed, randomly selected
         show_hist : bool, optional
             show the data density as a a 2d histogram, by default True
         backend : str, optional
@@ -930,9 +932,6 @@ class BaseComparer:
 
         if title is None:
             title = f"{self.mod_names[mod_id]} vs {self.name}"
-
-        if show_points is None:
-            show_points = len(x) < 1e4
 
         scatter(
             x=x,

--- a/fmskill/comparison.py
+++ b/fmskill/comparison.py
@@ -815,7 +815,7 @@ class BaseComparer:
         *,
         binsize: float = None,
         nbins: int = 20,
-        show_points: Union[bool, int, str] = None,
+        show_points: Union[bool, int, float] = None,
         show_hist: bool = True,
         backend: str = "matplotlib",
         figsize: List[float] = (8, 8),
@@ -843,10 +843,10 @@ class BaseComparer:
             the size of each bin in the 2d histogram, by default None
         nbins : int, optional
             number of bins (if binsize is not given), by default 20
-        show_points : (bool, int, str), optional
+        show_points : (bool, int, float), optional
             Should the scatter points be displayed?
-            None means: only show points if fewer than threshold, by default None.
-            'sample': will display a random sample of 10,000 points.
+            None means: show all points if fewer than 1e4, otherwise show 1e4 sample points, by default None.
+            float: fraction of points to show on plot from 0 to 1. eg 0.5 shows 50% of the points.
             int: if 'n' (int) given, then 'n' points will be displayed, randomly selected
         show_hist : bool, optional
             show the data density as a a 2d histogram, by default True

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -85,13 +85,21 @@ def scatter(
             show_points = False
     elif show_points == "sample":
         np.random.seed(20)
-        x_sample = np.random.choice(x, 1e4)
-        y_sample = np.random.choice(y, 1e4)
+        ran_index = np.random.choice(range(len(x)), 10000)
+        x_sample = x[ran_index]
+        y_sample = y[ran_index]
     # if show_points is an int
     elif type(show_points) == int:
         np.random.seed(20)
-        x_sample = np.random.choice(x, show_points)
-        y_sample = np.random.choice(y, show_points)
+        ran_index = np.random.choice(range(len(x)), show_points)
+        x_sample = x[ran_index]
+        y_sample = y[ran_index]
+    elif show_points == True:
+        pass
+    else:
+        raise TypeError(" `show_points` must be either bool, int or 'sample' ")
+
+    print(len(x_sample))
 
     xmin, xmax = x.min(), x.max()
     ymin, ymax = y.min(), y.max()

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -94,12 +94,10 @@ def scatter(
         ran_index = np.random.choice(range(len(x)), show_points)
         x_sample = x[ran_index]
         y_sample = y[ran_index]
-    elif show_points == True:
+    elif type(show_points) == bool:
         pass
     else:
         raise TypeError(" `show_points` must be either bool, int or 'sample' ")
-
-    print(len(x_sample))
 
     xmin, xmax = x.min(), x.max()
     ymin, ymax = y.min(), y.max()

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -1,4 +1,3 @@
-from dataclasses import replace
 from typing import List, Tuple, Union
 import warnings
 import numpy as np

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from typing import List, Tuple, Union
 import warnings
 import numpy as np
@@ -18,7 +19,7 @@ def scatter(
     *,
     binsize: float = None,
     nbins: int = 20,
-    show_points: Union[bool, int, str] = None,
+    show_points: Union[bool, int, float] = None,
     show_hist: bool = True,
     backend: str = "matplotlib",
     figsize: List[float] = (8, 8),
@@ -43,9 +44,9 @@ def scatter(
         the size of each bin in the 2d histogram, by default None
     nbins : int, optional
         number of bins (if binsize is not given), by default 20
-    show_points : (bool, int, str), optional
+    show_points : (bool, int, float), optional
         Should the scatter points be displayed?
-        None means: only show points if fewer than threshold, by default None.
+        None means: show all points if fewer than 1e4, otherwise show 1e4 sample points, by default None.
         float: fraction of points to show on plot from 0 to 1. eg 0.5 shows 50% of the points.
         int: if 'n' (int) given, then 'n' points will be displayed, randomly selected.
     show_hist : bool, optional
@@ -78,23 +79,25 @@ def scatter(
     x_sample = x
     y_sample = y
     if show_points is None:
-        # If nothing given, and more than 10k points, nothing will be shown
+        # If nothing given, and more than 10k points, 10k sample will be shown
         if len(x) < 1e4:
             show_points = True
         else:
-            show_points = False
-    elif type(show_points) == float:
+            show_points = 10000
+    if type(show_points) == float:
         if show_points < 0 or show_points > 1:
-            raise TypeError(" `show_points` fraction must be in [0,1]")
+            raise ValueError(" `show_points` fraction must be in [0,1]")
         else:
             np.random.seed(20)
-            ran_index = np.random.choice(range(len(x)), int(len(x) * show_points))
+            ran_index = np.random.choice(
+                range(len(x)), int(len(x) * show_points), replace=False
+            )
             x_sample = x[ran_index]
             y_sample = y[ran_index]
     # if show_points is an int
     elif type(show_points) == int:
         np.random.seed(20)
-        ran_index = np.random.choice(range(len(x)), show_points)
+        ran_index = np.random.choice(range(len(x)), show_points, replace=False)
         x_sample = x[ran_index]
         y_sample = y[ran_index]
     elif type(show_points) == bool:

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -88,7 +88,7 @@ def scatter(
             raise TypeError(" `show_points` fraction must be in [0,1]")
         else:
             np.random.seed(20)
-            ran_index = np.random.choice(range(len(x)), len(x) * show_points)
+            ran_index = np.random.choice(range(len(x)), int(len(x) * show_points))
             x_sample = x[ran_index]
             y_sample = y[ran_index]
     # if show_points is an int

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -46,7 +46,7 @@ def scatter(
     show_points : (bool, int, str), optional
         Should the scatter points be displayed?
         None means: only show points if fewer than threshold, by default None.
-        'sample': will display a random sample of 10,000 points.
+        float: fraction of points to show on plot from 0 to 1. eg 0.5 shows 50% of the points.
         int: if 'n' (int) given, then 'n' points will be displayed, randomly selected.
     show_hist : bool, optional
         show the data density as a a 2d histogram, by default True
@@ -83,11 +83,14 @@ def scatter(
             show_points = True
         else:
             show_points = False
-    elif show_points == "sample":
-        np.random.seed(20)
-        ran_index = np.random.choice(range(len(x)), 10000)
-        x_sample = x[ran_index]
-        y_sample = y[ran_index]
+    elif type(show_points) == float:
+        if show_points < 0 or show_points > 1:
+            raise TypeError(" `show_points` fraction must be in [0,1]")
+        else:
+            np.random.seed(20)
+            ran_index = np.random.choice(range(len(x)), len(x) * show_points)
+            x_sample = x[ran_index]
+            y_sample = y[ran_index]
     # if show_points is an int
     elif type(show_points) == int:
         np.random.seed(20)
@@ -97,7 +100,7 @@ def scatter(
     elif type(show_points) == bool:
         pass
     else:
-        raise TypeError(" `show_points` must be either bool, int or 'sample' ")
+        raise TypeError(" `show_points` must be either bool, int or float")
 
     xmin, xmax = x.min(), x.max()
     ymin, ymax = y.min(), y.max()


### PR DESCRIPTION
Added the options of showing just a `sample` of scatter points (of 10k randomly selected points) or `N` number of points, also randomly selected.  A fixed random seed was hardcoded.