### PR TITLE
Adding models for the same observation after construction to Connector fails 

### DIFF
--- a/fmskill/connection.py
+++ b/fmskill/connection.py
@@ -141,6 +141,15 @@ class _SingleObsConnector(_BaseConnector):
             self.obs.weight = weight
 
     def _parse_model(self, mod) -> List[ModelResultInterface]:
+
+        if isinstance(mod, pd.DataFrame):
+            if len(mod.columns) == 1:
+                return [self._parse_single_model(mod)]
+            else:
+                raise NotImplementedError(
+                    "Only data frames with a single column are allowed"
+                )
+
         if is_iterable_not_str(mod):
             mr = []
             for m in mod:
@@ -467,9 +476,13 @@ class Connector(_BaseConnector, Mapping, Sequence):
                 con = TrackConnector(obs, mod, weight=weight, validate=validate)
             else:
                 con = PointConnector(obs, mod, weight=weight, validate=validate)
-        if con.n_models > 0:
-            self.connections[con.name] = con
-            self._add_observation(con.obs)
+        if con.n_models > 0:  # What other option is there??
+            if con.name not in self.connections:
+                self.connections[con.name] = con
+                self._add_observation(con.obs)
+            else:
+                self.connections[con.name].modelresults.append(con.modelresults[0])
+
             self._add_modelresults(con.modelresults)
 
     @staticmethod

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -65,10 +65,29 @@ def test_connector_add(o1, mr1):
     assert len(con.observations) == 1
 
 
+def test_connector_add_two_models(
+    o1: PointObservation, mr1: ModelResult, mr2: ModelResult
+):
+
+    con = Connector(o1, [mr1[0], mr2[0]])
+
+    assert con.n_models == 2
+    cc = con.extract()
+    assert cc.n_models == 2
+
+    # Alternative specification using .add() should be identical
+    con2 = Connector()
+    con2.add(o1, mr1[0])
+    con2.add(o1, mr2[0])
+
+    assert con2.n_models == 2
+    cc2 = con2.extract()
+    assert cc2.n_models == 2
+
+
 def test_connector_add_two_model_dataframes(
     o1: PointObservation, mr1: ModelResult, mr2: ModelResult
 ):
-    con = Connector()
 
     mr1_df = mr1[0]._extract_point_dfsu(x=o1.x, y=o1.y, item=0).to_dataframe()
     mr2_df = mr2[0]._extract_point_dfsu(x=o1.x, y=o1.y, item=0).to_dataframe()
@@ -82,11 +101,20 @@ def test_connector_add_two_model_dataframes(
     assert len(mr1_df) > 1  # Number of rows
     assert len(mr2_df) > 1  # Number of rows
 
-    con.add(o1, mr1_df)
-    con.add(o1, mr2_df)
-    con.extract()
+    con = Connector(o1, [mr1_df, mr2_df])
 
     assert con.n_models == 2
+    cc = con.extract()
+    assert cc.n_models == 2
+
+    # Alternative specification using .add() should be identical
+    con2 = Connector()
+    con2.add(o1, mr1_df)
+    con2.add(o1, mr2_df)
+
+    assert con2.n_models == 2
+    cc2 = con2.extract()
+    assert cc2.n_models == 2
 
 
 # def test_add_observation_eum_validation(hd_oresund_2d, klagshamn):

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1,5 +1,6 @@
 from mikeio import eum
 import pytest
+import pandas as pd
 
 from fmskill import ModelResult
 from fmskill import PointObservation, TrackObservation
@@ -62,6 +63,30 @@ def test_connector_add(o1, mr1):
     con = Connector()
     con.add(o1, mr1[0], validate=False)
     assert len(con.observations) == 1
+
+
+def test_connector_add_two_model_dataframes(
+    o1: PointObservation, mr1: ModelResult, mr2: ModelResult
+):
+    con = Connector()
+
+    mr1_df = mr1[0]._extract_point_dfsu(x=o1.x, y=o1.y, item=0).to_dataframe()
+    mr2_df = mr2[0]._extract_point_dfsu(x=o1.x, y=o1.y, item=0).to_dataframe()
+
+    assert isinstance(mr1_df, pd.DataFrame)
+    assert isinstance(mr2_df, pd.DataFrame)
+
+    assert len(mr1_df.columns == 1)
+    assert len(mr2_df.columns == 1)
+
+    assert len(mr1_df) > 1  # Number of rows
+    assert len(mr2_df) > 1  # Number of rows
+
+    con.add(o1, mr1_df)
+    con.add(o1, mr2_df)
+    con.extract()
+
+    assert con.n_models == 2
 
 
 # def test_add_observation_eum_validation(hd_oresund_2d, klagshamn):


### PR DESCRIPTION
```python
con = Connector(o1, [mr1[0], mr2[0]])
cc = con.extract()
# Alternative specification using .add() should be identical
con2 = Connector()
con2.add(o1, mr1[0])
con2.add(o1, mr2[0])
```