### PR TITLE
added skill table if requested

### DIFF
--- a/fmskill/comparison.py
+++ b/fmskill/comparison.py
@@ -839,6 +839,7 @@ class BaseComparer:
         df: pd.DataFrame = None,
         binsize: float = None,
         nbins: int = None,
+        skill_table: bool = False,
         **kwargs,
     ):
         """Scatter plot showing compared data: observation vs modelled
@@ -900,6 +901,9 @@ class BaseComparer:
             by default None
         df : pd.dataframe, optional
             show user-provided data instead of the comparers own data, by default None
+        skill_table : bool, optional
+            calculates the main skills (bias, rmse, si, r2, etc) and adds a box at
+            the right of the scatter plot, by default False
         kwargs
 
         Examples
@@ -947,6 +951,7 @@ class BaseComparer:
 
         if title is None:
             title = f"{self.mod_names[mod_id]} vs {self.name}"
+        
 
         scatter(
             x=x,
@@ -968,6 +973,24 @@ class BaseComparer:
             nbins=nbins,
             **kwargs,
         )
+        if skill_table:
+            #Calculate Skill if it was requested to add as table on the right of plot
+            skill_df=self.skill(metrics=['bias', 'rmse', 'urmse', 'mae', 'cc', 'si', 'r2'],
+                                model=mod_name,
+                                observation=observation,
+                                start=start,
+                                end=end) 
+            text_=''
+            for col in skill_df.df.columns:
+                if col=='model':
+                    continue
+                text_=text_+f"{col}={np.round(skill_df.df[col].values[0],3)}\n"
+
+
+            plt.gcf().text(0.97, 0.6, text_,
+            bbox={'facecolor': 'blue','edgecolor':'k','boxstyle':'round','alpha':0.05},
+            fontsize=12)
+
 
     def taylor(
         self,

--- a/fmskill/comparison.py
+++ b/fmskill/comparison.py
@@ -951,7 +951,6 @@ class BaseComparer:
 
         if title is None:
             title = f"{self.mod_names[mod_id]} vs {self.name}"
-        
 
         scatter(
             x=x,
@@ -974,23 +973,36 @@ class BaseComparer:
             **kwargs,
         )
         if skill_table:
-            #Calculate Skill if it was requested to add as table on the right of plot
-            skill_df=self.skill(metrics=['bias', 'rmse', 'urmse', 'mae', 'cc', 'si', 'r2'],
-                                model=mod_name,
-                                observation=observation,
-                                start=start,
-                                end=end) 
-            text_=''
+            # Calculate Skill if it was requested to add as table on the right of plot
+            skill_df = self.skill(
+                metrics=["bias", "rmse", "urmse", "mae", "cc", "si", "r2"], df=df
+            )  # df is filtered to matching subset
+            lines = []
+
+            max_str_len = skill_df.df.columns.str.len().max()
+
             for col in skill_df.df.columns:
-                if col=='model':
+                if col == "model":
                     continue
-                text_=text_+f"{col}={np.round(skill_df.df[col].values[0],3)}\n"
+                lines.append(
+                    f"{col.ljust(max_str_len)} {np.round(skill_df.df[col].values[0],3)}"
+                )
 
+            text_ = "\n".join(lines)
 
-            plt.gcf().text(0.97, 0.6, text_,
-            bbox={'facecolor': 'blue','edgecolor':'k','boxstyle':'round','alpha':0.05},
-            fontsize=12)
-
+            plt.gcf().text(
+                0.97,
+                0.6,
+                text_,
+                bbox={
+                    "facecolor": "blue",
+                    "edgecolor": "k",
+                    "boxstyle": "round",
+                    "alpha": 0.05,
+                },
+                fontsize=12,
+                family="monospace",
+            )
 
     def taylor(
         self,


### PR DESCRIPTION
Hi, I added an additional flag for scatter plots (point comparison only for the moment) that adds basic statistics table on the right side. Example:
* `comparer.scatter(model=modname,cmap='rainbow',
                                xlabel='Observation Hm0 [m]',
                               ylabel='Model Hm0 [m]',show_density=True,
                                )` gives the normal scatter
![image](https://user-images.githubusercontent.com/97288080/190642924-a5e7febf-b14e-45d7-bae9-eaa861003e18.png)
* adding the `skill_table=True` flag then makes it like this `comparer.scatter(model=modname,cmap='rainbow',
                                xlabel='Observation Hm0 [m]',
                               ylabel='Model Hm0 [m]',show_density=True,
                                skill_table=True)` 
![image](https://user-images.githubusercontent.com/97288080/190643169-42bfcd94-1028-4b67-8c85-988e036bd18c.png)

Still to implement:
* Table flag for the spatial-skill scatter plot
*  Add dimensions (metres, seconds, etc.) as of right now fmskill does not take into account the physical unites (dimensions) of the comparisons