### PR TITLE
added units flag scatter

### DIFF
--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]      
+        python-version: ["3.8", "3.9", "3.10"]      
 
     steps:
     - uses: actions/checkout@v2

--- a/fmskill/comparison.py
+++ b/fmskill/comparison.py
@@ -956,9 +956,9 @@ class BaseComparer:
         if skill_table != None:
             # Calculate Skill if it was requested to add as table on the right of plot
             if skill_table==True:
-                skill_df = self.skill(df=df)  
+                skill_df = self.skill(df=df,model=model,observation=observation,variable=variable)  
             elif type(skill_table)==list:
-                skill_df = self.skill(df=df,metrics=skill_table)  
+                skill_df = self.skill(df=df,metrics=skill_table,model=model,observation=observation,variable=variable)  
             stats_with_units=["bias", "rmse", "urmse", "mae","max_error"]
             # Check for units
             try:

--- a/fmskill/comparison.py
+++ b/fmskill/comparison.py
@@ -987,16 +987,7 @@ class BaseComparer:
             if units==None:
                 #Check for units
                 try:
-                    #Extract first letter of most common dfs0 units in SI;
-                    #either (m)eter, (s)econd, (deg)gree, or (m/s). Rest of units can
-                    #always be assigned by user with `units=str` keyword
-                    units_=self._itemInfos[0].unit.display_name
-                    if units_=='meter' or units_=='second':
-                        units_=units_[0]
-                    elif units_=='degree':
-                        units_='°'
-                    elif units_=='meter per sec':
-                        units_='m/s'
+                    units_=unit_text.split('[')[1].split(']')[0]
                 except:
                     #Dimensionless
                     units_=''
@@ -1006,12 +997,14 @@ class BaseComparer:
                 if col == "model":
                     continue
                 if col in stats_with_units:
-                    lines.append(
-                    f"{(col.ljust(max_str_len)).upper()} {np.round(skill_df.df[col].values[0],3)} {units_}"
-                )
+                    #if statistic has dimensions, then add units
+                    item_unit=units_
                 else:
-                    lines.append(
-                    f"{(col.ljust(max_str_len)).upper()} {np.round(skill_df.df[col].values[0],3)}"
+                    #else, add empty space (for fomatting)
+                    item_unit=' '
+
+                lines.append(
+                    f"{(col.ljust(max_str_len)).upper()} {np.round(skill_df.df[col].values[0],3)} {item_unit}"
                 )
 
             text_ = "\n".join(lines)

--- a/fmskill/comparison.py
+++ b/fmskill/comparison.py
@@ -840,6 +840,7 @@ class BaseComparer:
         binsize: float = None,
         nbins: int = None,
         skill_table: bool = False,
+        units: str = None,
         **kwargs,
     ):
         """Scatter plot showing compared data: observation vs modelled
@@ -904,6 +905,9 @@ class BaseComparer:
         skill_table : bool, optional
             calculates the main skills (bias, rmse, si, r2, etc) and adds a box at
             the right of the scatter plot, by default False
+        units : str, optional
+            add units to plots. By default will use units of dfs0 file. If dataframe is provided,
+            then a str can be specified. By default None
         kwargs
 
         Examples
@@ -977,15 +981,37 @@ class BaseComparer:
             skill_df = self.skill(
                 metrics=["bias", "rmse", "urmse", "mae", "cc", "si", "r2"], df=df
             )  # df is filtered to matching subset
+            stats_with_units=["bias", "rmse", "urmse", "mae"]
+            
             lines = []
-
+            if units==None:
+                #Check for units
+                try:
+                    #Extract first letter of most common dfs0 units in SI;
+                    #either (m)eter, (s)econd, (deg)gree, or (m/s). Rest of units can
+                    #always be assigned by user with `units=str` keyword
+                    units_=self._itemInfos[0].unit.display_name
+                    if units_=='meter' or units_=='second':
+                        units_=units_[0]
+                    elif units_=='degree':
+                        units_='°'
+                    elif units_=='meter per sec':
+                        units_='m/s'
+                except:
+                    #Dimensionless
+                    units_=''
             max_str_len = skill_df.df.columns.str.len().max()
 
             for col in skill_df.df.columns:
                 if col == "model":
                     continue
-                lines.append(
-                    f"{col.ljust(max_str_len)} {np.round(skill_df.df[col].values[0],3)}"
+                if col in stats_with_units:
+                    lines.append(
+                    f"{(col.ljust(max_str_len)).upper()} {np.round(skill_df.df[col].values[0],3)} {units_}"
+                )
+                else:
+                    lines.append(
+                    f"{(col.ljust(max_str_len)).upper()} {np.round(skill_df.df[col].values[0],3)}"
                 )
 
             text_ = "\n".join(lines)

--- a/fmskill/comparison.py
+++ b/fmskill/comparison.py
@@ -1004,7 +1004,7 @@ class BaseComparer:
                     item_unit=' '
 
                 lines.append(
-                    f"{(col.ljust(max_str_len)).upper()} {np.round(skill_df.df[col].values[0],3)} {item_unit}"
+                    f"{(col.ljust(max_str_len)).upper()} {np.round(skill_df.df[col].values[0],2):.2f} {item_unit}"
                 )
 
             text_ = "\n".join(lines)

--- a/fmskill/comparison.py
+++ b/fmskill/comparison.py
@@ -839,8 +839,7 @@ class BaseComparer:
         df: pd.DataFrame = None,
         binsize: float = None,
         nbins: int = None,
-        skill_table: bool = False,
-        units: str = None,
+        skill_table: Union[str, List[str], bool] = None,
         **kwargs,
     ):
         """Scatter plot showing compared data: observation vs modelled
@@ -902,12 +901,10 @@ class BaseComparer:
             by default None
         df : pd.dataframe, optional
             show user-provided data instead of the comparers own data, by default None
-        skill_table : bool, optional
-            calculates the main skills (bias, rmse, si, r2, etc) and adds a box at
-            the right of the scatter plot, by default False
-        units : str, optional
-            add units to plots. By default will use units of dfs0 file. If dataframe is provided,
-            then a str can be specified. By default None
+        skill_table : str, List[str], bool, optional
+            list of fmskill.metrics or boolean, if True then by default [bias, rmse, urmse, mae, cc, si, r2].
+            This kword adds a box at the right of the scatter plot, 
+            by default False 
         kwargs
 
         Examples
@@ -955,6 +952,27 @@ class BaseComparer:
 
         if title is None:
             title = f"{self.mod_names[mod_id]} vs {self.name}"
+        
+        if skill_table != None:
+            # Calculate Skill if it was requested to add as table on the right of plot
+            if skill_table==True:
+                skill_df = self.skill(df=df)  
+            elif type(skill_table)==list:
+                skill_df = self.skill(df=df,metrics=skill_table)  
+            stats_with_units=["bias", "rmse", "urmse", "mae","max_error"]
+            # Check for units
+            try:
+                units=unit_text.split('[')[1].split(']')[0]
+            except:
+                #     Dimensionless
+                units=''
+            if skill_table==False:
+                skill_df=None
+                units=None
+        else:
+            # skill_table is None
+            skill_df=None
+            units=None
 
         scatter(
             x=x,
@@ -972,61 +990,12 @@ class BaseComparer:
             title=title,
             xlabel=xlabel,
             ylabel=ylabel,
+            skill_df= skill_df,
+            units=units,
             binsize=binsize,
             nbins=nbins,
             **kwargs,
         )
-        if skill_table:
-            # Calculate Skill if it was requested to add as table on the right of plot
-            skill_df = self.skill(
-                #default metrics
-                metrics=["bias", "rmse", "mae", "cc", "si", "r2"], df=df
-            )  # df is filtered to matching subset
-            stats_with_units=["bias", "rmse", "urmse", "mae"]
-            
-            lines = []
-            if units==None:
-                #Check for units
-                try:
-                    units_=unit_text.split('[')[1].split(']')[0]
-                except:
-                    #Dimensionless
-                    units_=''
-            max_str_len = skill_df.df.columns.str.len().max()
-
-            for col in skill_df.df.columns:
-                if col == "model":
-                    continue
-                if col in stats_with_units:
-                    #if statistic has dimensions, then add units
-                    item_unit=units_
-                else:
-                    #else, add empty space (for fomatting)
-                    item_unit=' '
-                if col=="n":
-                    # Number of samples, integer, else, 2 decimals
-                    decimals=f'.{0}f'
-                else:
-                    decimals=f'.{2}f'
-                lines.append(
-                    f"{(col.ljust(max_str_len)).upper()} {np.round(skill_df.df[col].values[0],2):{decimals}} {item_unit}"
-                )
-
-            text_ = "\n".join(lines)
-
-            plt.gcf().text(
-                0.97,
-                0.6,
-                text_,
-                bbox={
-                    "facecolor": "blue",
-                    "edgecolor": "k",
-                    "boxstyle": "round",
-                    "alpha": 0.05,
-                },
-                fontsize=12,
-                family="monospace",
-            )
 
     def taylor(
         self,

--- a/fmskill/comparison.py
+++ b/fmskill/comparison.py
@@ -979,7 +979,8 @@ class BaseComparer:
         if skill_table:
             # Calculate Skill if it was requested to add as table on the right of plot
             skill_df = self.skill(
-                metrics=["bias", "rmse", "urmse", "mae", "cc", "si", "r2"], df=df
+                #default metrics
+                metrics=["bias", "rmse", "mae", "cc", "si", "r2"], df=df
             )  # df is filtered to matching subset
             stats_with_units=["bias", "rmse", "urmse", "mae"]
             
@@ -1002,9 +1003,13 @@ class BaseComparer:
                 else:
                     #else, add empty space (for fomatting)
                     item_unit=' '
-
+                if col=="n":
+                    # Number of samples, integer, else, 2 decimals
+                    decimals=f'.{0}f'
+                else:
+                    decimals=f'.{2}f'
                 lines.append(
-                    f"{(col.ljust(max_str_len)).upper()} {np.round(skill_df.df[col].values[0],2):.2f} {item_unit}"
+                    f"{(col.ljust(max_str_len)).upper()} {np.round(skill_df.df[col].values[0],2):{decimals}} {item_unit}"
                 )
 
             text_ = "\n".join(lines)

--- a/fmskill/observation.py
+++ b/fmskill/observation.py
@@ -494,6 +494,6 @@ def unit_display_name(name: str) -> str:
     m
     """
 
-    res = name.replace("meter", "m").replace("_per_", "/").replace("sec", "s")
+    res = name.replace("meter", "m").replace("_per_", "/").replace("second", "s")
 
     return res

--- a/fmskill/observation.py
+++ b/fmskill/observation.py
@@ -494,6 +494,6 @@ def unit_display_name(name: str) -> str:
     m
     """
 
-    res = name.replace("meter", "m").replace("_per_", "/").replace("second", "s")
+    res = name.replace("meter", "m").replace("_per_", "/").replace("second", "s").replace("sec", "s")
 
     return res

--- a/fmskill/observation.py
+++ b/fmskill/observation.py
@@ -45,7 +45,7 @@ class Observation:
     # matplotlib: red=#d62728
 
     def __init__(
-        self, name: str = None, df=None, itemInfo=None, variable_name: str = None
+        self, name: str = None, df=None, itemInfo=None, variable_name: str = None, override_units: str = None,
     ):
         self.color = "#d62728"
 
@@ -67,7 +67,7 @@ class Observation:
         if variable_name is None:
             variable_name = self.itemInfo.type.name
         self.variable_name = variable_name
-
+        self.override_units= override_units
     @property
     def time(self) -> pd.DatetimeIndex:
         "Time index"
@@ -99,12 +99,17 @@ class Observation:
         return self._filename
 
     def _unit_text(self):
+        override_units=self.override_units
         if self.itemInfo is None:
             return ""
         txt = f"{self.itemInfo.type.display_name}"
         if self.itemInfo.type != mikeio.EUMType.Undefined:
-            unit = self.itemInfo.unit.display_name
-            txt = f"{txt} [{unit_display_name(unit)}]"
+            if override_units==None:
+                unit = self.itemInfo.unit.display_name
+                txt = f"{txt} [{unit_display_name(unit)}]"
+            else:
+                unit = override_units
+                txt = f"{txt} [{override_units}]"
         return txt
 
     def hist(self, bins=100, title=None, color=None, **kwargs):
@@ -162,6 +167,8 @@ class PointObservation(Observation):
         user-defined name for easy identification in plots etc, by default file basename
     variable_name : str, optional
         user-defined variable name in case of multiple variables, by default eumType name
+    units : str, optional
+        user-defined units name in case user wants to override eumUnits 
 
     Examples
     --------
@@ -191,6 +198,7 @@ class PointObservation(Observation):
         z: float = None,
         name: str = None,
         variable_name: str = None,
+        units: str = None,
     ):
 
         self.x = x
@@ -254,7 +262,7 @@ class PointObservation(Observation):
             )
 
         super().__init__(
-            name=name, df=df, itemInfo=itemInfo, variable_name=variable_name
+            name=name, df=df, itemInfo=itemInfo, variable_name=variable_name, override_units=units, 
         )
 
     def __repr__(self):
@@ -333,6 +341,8 @@ class TrackObservation(Observation):
         item name or index of y-coordinate, by default 1
     offset_duplicates : float, optional
         in case of duplicate timestamps, add this many seconds to consecutive duplicate entries, by default 0.001
+    units : str, optional
+        user-defined units name in case user wants to override eumUnits 
 
 
     Examples
@@ -408,6 +418,7 @@ class TrackObservation(Observation):
         x_item=0,
         y_item=1,
         offset_duplicates: float = 0.001,
+        units: str = None,
     ):
 
         self._filename = None
@@ -446,7 +457,7 @@ class TrackObservation(Observation):
             df.index = make_unique_index(df.index, offset_duplicates=offset_duplicates)
 
         super().__init__(
-            name=name, df=df, itemInfo=itemInfo, variable_name=variable_name
+            name=name, df=df, itemInfo=itemInfo, variable_name=variable_name,override_units=units,
         )
 
     @staticmethod

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -524,8 +524,12 @@ def _plot_summary_table(skill_df,units,max_cbar):
         x=0.93
     elif max_cbar<1e5:
         x=0.97
-    else:
+    elif max_cbar<1e6:
         x=1.05
+    else:
+        #When more than 1e6 samples, matplotlib changes to scientific notation
+        x=0.97
+
     plt.gcf().text(
                 x,
                 0.6,

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -500,8 +500,12 @@ def _plot_summary_table(skill_df,units,max_cbar):
     stats_with_units=["bias", "rmse", "urmse", "mae"]
     max_str_len = skill_df.columns.str.len().max()
     lines = []
+    if len(skill_df)>1:
+        raise Exception('''`skill_table` kword can only be used for comparisons between 1 model and 1 measurement. 
+        Please add `model`, `variable` and `observation` kwords where required''')
+
     for col in skill_df.columns:
-        if col == "model":
+        if col == "model" or col == "variable":
             continue
         if col in stats_with_units:
             #if statistic has dimensions, then add units
@@ -522,8 +526,12 @@ def _plot_summary_table(skill_df,units,max_cbar):
 
     if max_cbar==None:
         x=0.93
+    elif max_cbar<1e3:
+        x=0.99
+    elif max_cbar<1e4:
+        x=1.01
     elif max_cbar<1e5:
-        x=0.97
+        x=1.03
     elif max_cbar<1e6:
         x=1.05
     else:

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -30,6 +30,8 @@ def scatter(
     title: str = "",
     xlabel: str = "",
     ylabel: str = "",
+    skill_df: object = None,
+    units: str = "",
     binsize: float = None,
     nbins: int = None,
     **kwargs,
@@ -81,6 +83,10 @@ def scatter(
         x-label text on plot, by default None
     ylabel : str, optional
         y-label text on plot, by default None
+    skill_df : dataframe, optional
+        dataframe with skill (stats) results to be added to plot, by default None
+    units : str, optional
+        user default units to override default units, eg 'metre', by default None
     kwargs
     """
 
@@ -253,10 +259,18 @@ def scatter(
         plt.grid(
             which="both", axis="both", linestyle=":", linewidth="0.2", color="grey"
         )
+        max_cbar=None
         if show_hist or show_density:
             cbar = plt.colorbar(fraction=0.046, pad=0.04)
-            cbar.set_label("# points")
+            ticks = cbar.ax.get_yticks()
+            max_cbar=ticks[-1]
+            cbar.set_label("# points")        
+            
         plt.title(title)
+        # Add skill table
+        if skill_df != None:
+            _plot_summary_table(skill_df,units,max_cbar=max_cbar)
+        
 
     elif backend == "plotly":  # pragma: no cover
         import plotly.graph_objects as go
@@ -481,3 +495,47 @@ def _scatter_density(x, y, binsize: float = 0.1, method: str = "linear"):
     Z_grid[(Z_grid < 0)] = 0
 
     return Z_grid
+
+def _plot_summary_table(skill_df,units,max_cbar):
+    stats_with_units=["bias", "rmse", "urmse", "mae"]
+    max_str_len = skill_df.columns.str.len().max()
+    lines = []
+    for col in skill_df.columns:
+        if col == "model":
+            continue
+        if col in stats_with_units:
+            #if statistic has dimensions, then add units
+            item_unit=units
+        else:
+            #else, add empty space (for fomatting)
+            item_unit=' '
+        if col=="n":
+            # Number of samples, integer, else, 2 decimals
+            decimals=f'.{0}f'
+        else:
+            decimals=f'.{2}f'
+        lines.append(
+            f"{(col.ljust(max_str_len)).upper()} {np.round(skill_df[col].values[0],2):{decimals}} {item_unit}"
+                )
+
+    text_ = "\n".join(lines)
+
+    if max_cbar==None:
+        x=0.93
+    elif max_cbar<1e5:
+        x=0.97
+    else:
+        x=1.05
+    plt.gcf().text(
+                x,
+                0.6,
+                text_,
+                bbox={
+                    "facecolor": "blue",
+                    "edgecolor": "k",
+                    "boxstyle": "round",
+                    "alpha": 0.05,
+                },
+                fontsize=12,
+                family="monospace",
+            )

--- a/tests/test_eum.py
+++ b/tests/test_eum.py
@@ -5,3 +5,4 @@ def test_units_display_name():
 
     assert unit_display_name("meter") == "m"
     assert unit_display_name("meter_per_sec") == "m/s"
+    assert unit_display_name("second") == "s"

--- a/tests/test_multimodelcompare.py
+++ b/tests/test_multimodelcompare.py
@@ -275,6 +275,7 @@ def test_mm_scatter(cc):
     cc.scatter(model="SW_2", show_points=0.75)
     cc.scatter(model="SW_2", show_density=True)
     cc.scatter(model="SW_2", show_points=0.75, show_density=True)
+    cc.scatter(model="SW_2", observation='HKNA',skill_table=True)
     # cc.scatter(model="SW_2", binsize=0.5, backend="plotly")
     assert True
     plt.close("all")

--- a/tests/test_multivariable_compare.py
+++ b/tests/test_multivariable_compare.py
@@ -119,6 +119,7 @@ def test_mv_mm_mean_skill(cc):
 def test_mv_mm_scatter(cc):
     cc.scatter(model="SW_1", variable="Wind_speed")
     cc.scatter(model="SW_1", variable="Wind_speed", show_density=True)
+    cc.scatter(model="SW_1", variable="Wind_speed", observation = 'F16_wind', skill_table=True)
     assert True
     plt.close("all")
 

--- a/tests/test_pointobservation.py
+++ b/tests/test_pointobservation.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import pytest
 import sys
+import mikeio
 
 from fmskill.observation import PointObservation
 
@@ -16,6 +17,18 @@ def test_from_dfs0(klagshamn):
 
     o2 = PointObservation(klagshamn, item="Water Level", x=366844, y=6154291)
     assert o1.n_points == o2.n_points
+
+    o3 = PointObservation(klagshamn, item="Water Level", x=366844, y=6154291, units='meter')
+    assert o3.override_units == o2.itemInfo.unit.name
+
+    o4 = PointObservation(klagshamn, item="Water Level", x=366844, y=6154291)
+    assert o4.override_units == None
+
+    o5 = PointObservation(klagshamn, item="Water Level", x=366844, y=6154291)
+    assert o5._unit_text() == 'Water Level [m]'
+
+    o6 = PointObservation(klagshamn, item="Water Level", x=366844, y=6154291, units='inches')
+    assert o6._unit_text() == "Water Level [inches]"
 
 
 def test_from_df(klagshamn):
@@ -34,6 +47,13 @@ def test_from_df(klagshamn):
     assert isinstance(s, pd.Series)
     o3 = PointObservation(s, x=366844, y=6154291, name="Klagshamn3")
     assert o1.n_points == o3.n_points
+
+    o4 = PointObservation(df, item="Water Level", x=366844, y=6154291, units='metre')
+    assert o4.override_units == 'metre'
+
+    o5 = PointObservation(df, item="Water Level", x=366844, y=6154291, units='inches')
+    o5.itemInfo = mikeio.ItemInfo(mikeio.EUMType.Water_Level) 
+    assert o5._unit_text() == "Water Level [inches]"
 
 
 @pytest.mark.skipif("shapely" not in sys.modules, reason="requires the shapely")

--- a/tests/test_trackobservation.py
+++ b/tests/test_trackobservation.py
@@ -16,6 +16,11 @@ def test_read(c2):
     assert len(o1.x) == o1.n_points
     assert o1.name == "c2"
     assert pytest.approx(o1.values.max()) == 17.67
+    assert o1.override_units == None
+    o2 = TrackObservation(c2, item=2, name="c2",units='inches/hour')
+    assert o2.override_units == 'inches/hour'
+    assert o2._unit_text() == "Wind speed [inches/hour]"
+    
 
 
 def test_from_df():


### PR DESCRIPTION
Added an automatic units recognition from dfs0.item for singlepoint compare object scatter plot.
* If not dfs0 is provided (or if user wants to override units) a new kword `units=str` can be specified, for instance if instead of automatic units detection `units = °` user wanted to specify degrees north then flag `units = ' °N'` can be specified.  
* Also, shortening of the very basic units was added ( metres -> m; second - >s; degrees -> °, and; meter per second -> m/s). For any other unit (eg **cm/s**) the automatic detection will just write *'centimetres per second'* and it will be the user the one who should specify kword `units = 'cm/s'` . This could be improved in the future with a very long mapping dictionary of `long unit name -> short unit name`.
* Before this commit scatter plot looked like this
![image](https://user-images.githubusercontent.com/97288080/191005553-21ad3556-5c25-4fc7-b8fd-b2d99e32d096.png)

now looks like this with units on the side (no extra kword, units extracted automatically from dfs0)

![image](https://user-images.githubusercontent.com/97288080/191005613-557a6961-75a4-4e35-8b93-89240e59b493.png)


* Still to do: Implement these changes in `track-comparer object` scatter plot (*should* be copy-pasting of the code)