### PR TITLE
Default style

### DIFF
--- a/fmskill/comparison.py
+++ b/fmskill/comparison.py
@@ -820,8 +820,8 @@ class BaseComparer:
         bins: Union[int, float, List[int], List[float]] = 20,
         quantiles: Union[int, List[float]] = None,
         show_points: Union[bool, int, float] = None,
-        show_hist: bool = True,
-        show_density: bool = False,
+        show_hist: bool = False,
+        show_density: bool = True,
         backend: str = "matplotlib",
         figsize: List[float] = (8, 8),
         xlim: List[float] = None,
@@ -862,9 +862,9 @@ class BaseComparer:
             float: fraction of points to show on plot from 0 to 1. eg 0.5 shows 50% of the points.
             int: if 'n' (int) given, then 'n' points will be displayed, randomly selected
         show_hist : bool, optional
-            show the data density as a a 2d histogram, by default True
+            show the data density as a a 2d histogram, by default False
         show_density: bool, optional
-            show the data density as a colormap of the scatter, by default False.
+            show the data density as a colormap of the scatter, by default True.
             for binning the data, the previous kword `bins=Float` is used
         backend : str, optional
             use "plotly" (interactive) or "matplotlib" backend, by default "matplotlib"

--- a/fmskill/comparison.py
+++ b/fmskill/comparison.py
@@ -820,8 +820,8 @@ class BaseComparer:
         bins: Union[int, float, List[int], List[float]] = 20,
         quantiles: Union[int, List[float]] = None,
         show_points: Union[bool, int, float] = None,
-        show_hist: bool = False,
-        show_density: bool = True,
+        show_hist: bool = None,
+        show_density: bool = None,
         backend: str = "matplotlib",
         figsize: List[float] = (8, 8),
         xlim: List[float] = None,
@@ -862,9 +862,10 @@ class BaseComparer:
             float: fraction of points to show on plot from 0 to 1. eg 0.5 shows 50% of the points.
             int: if 'n' (int) given, then 'n' points will be displayed, randomly selected
         show_hist : bool, optional
-            show the data density as a a 2d histogram, by default False
+            show the data density as a a 2d histogram, by default None
         show_density: bool, optional
-            show the data density as a colormap of the scatter, by default True.
+            show the data density as a colormap of the scatter, by default None. If both `show_density` and `show_hist`
+        are None, then `show_density` is used by default.
             for binning the data, the previous kword `bins=Float` is used
         backend : str, optional
             use "plotly" (interactive) or "matplotlib" backend, by default "matplotlib"

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -173,7 +173,11 @@ def scatter(
         # if not an int nor None, it must be a squence of floats
         xq = np.quantile(x, q=quantiles)
         yq = np.quantile(y, q=quantiles)
-
+    
+    if show_hist:
+        #if histogram is wanted (explicit non-default flag) then density is off
+        show_density=False
+        
     if show_density:
         if not ((type(bins) == float) or (type(bins) == int)):
             raise TypeError(

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -268,7 +268,7 @@ def scatter(
         plt.grid(
             which="both", axis="both", linestyle=":", linewidth="0.2", color="grey"
         )
-        if (show_hist or show_density):
+        if (show_hist or (show_density and show_points)):
             cbar = plt.colorbar(fraction=0.046, pad=0.04)
             cbar.set_label("# points")
         plt.title(title)

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -20,8 +20,8 @@ def scatter(
     bins: Union[int, float, List[int], List[float]] = 20,
     quantiles: Union[int, List[float]] = None,
     show_points: Union[bool, int, float] = None,
-    show_hist: bool = True,
-    show_density: bool = False,
+    show_hist: bool = False,
+    show_density: bool = True,
     backend: str = "matplotlib",
     figsize: List[float] = (8, 8),
     xlim: List[float] = None,
@@ -58,9 +58,9 @@ def scatter(
         float: fraction of points to show on plot from 0 to 1. eg 0.5 shows 50% of the points.
         int: if 'n' (int) given, then 'n' points will be displayed, randomly selected.
     show_hist : bool, optional
-        show the data density as a 2d histogram, by default True
+        show the data density as a 2d histogram, by default False
     show_density: bool, optional
-        show the data density as a colormap of the scatter, by default False.
+        show the data density as a colormap of the scatter, by default True.
         for binning the data, the previous kword `bins=Float` is used
     backend : str, optional
         use "plotly" (interactive) or "matplotlib" backend, by default "matplotlib"
@@ -101,11 +101,11 @@ def scatter(
     y_sample = y
 
     if show_points is None:
-        # If nothing given, and more than 10k points, 10k sample will be shown
-        if len(x) < 1e4:
+        # If nothing given, and more than 50k points, 50k sample will be shown
+        if len(x) < 5e4:
             show_points = True
         else:
-            show_points = 10000
+            show_points = 50000
     if type(show_points) == float:
         if show_points < 0 or show_points > 1:
             raise ValueError(" `show_points` fraction must be in [0,1]")

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -20,8 +20,8 @@ def scatter(
     bins: Union[int, float, List[int], List[float]] = 20,
     quantiles: Union[int, List[float]] = None,
     show_points: Union[bool, int, float] = None,
-    show_hist: bool = False,
-    show_density: bool = True,
+    show_hist: bool = None,
+    show_density: bool = None,
     backend: str = "matplotlib",
     figsize: List[float] = (8, 8),
     xlim: List[float] = None,
@@ -58,9 +58,10 @@ def scatter(
         float: fraction of points to show on plot from 0 to 1. eg 0.5 shows 50% of the points.
         int: if 'n' (int) given, then 'n' points will be displayed, randomly selected.
     show_hist : bool, optional
-        show the data density as a 2d histogram, by default False
+        show the data density as a 2d histogram, by default None
     show_density: bool, optional
-        show the data density as a colormap of the scatter, by default True.
+        show the data density as a colormap of the scatter, by default None. If both `show_density` and `show_hist`
+        are None, then `show_density` is used by default.
         for binning the data, the previous kword `bins=Float` is used
     backend : str, optional
         use "plotly" (interactive) or "matplotlib" backend, by default "matplotlib"
@@ -83,6 +84,10 @@ def scatter(
         y-label text on plot, by default None
     kwargs
     """
+    if show_hist==None and show_density==None:
+        #Default: points density
+        show_density=True
+
 
     if (binsize is not None) or (nbins is not None):
         warnings.warn(
@@ -176,7 +181,10 @@ def scatter(
     
     if show_hist:
         #if histogram is wanted (explicit non-default flag) then density is off
-        show_density=False
+        if show_density == True:
+            raise TypeError(
+                "if `show_hist=True` then `show_density` must be either `False` or `None`"
+            )        
         
     if show_density:
         if not ((type(bins) == float) or (type(bins) == int)):
@@ -184,7 +192,10 @@ def scatter(
                 "if `show_density=True` then bins must be either float or int"
             )
         # if point density is wanted, then 2D histogram is not shown
-        show_hist = False
+        if show_hist == True:
+            raise TypeError(
+                "if `show_density=True` then `show_hist` must be either `False` or `None`"
+            )    
         # calculate density data
         z = _scatter_density(x_sample, y_sample, binsize=binsize)
         idx = z.argsort()
@@ -234,7 +245,7 @@ def scatter(
             "X",
             label="Q-Q",
             c="darkturquoise",
-            markeredgecolor=(0, 0, 0, 0.6),
+            markeredgecolor=(0, 0, 0, 0.4),
             zorder=4,
         )
         plt.plot(
@@ -257,7 +268,7 @@ def scatter(
         plt.grid(
             which="both", axis="both", linestyle=":", linewidth="0.2", color="grey"
         )
-        if (show_hist or show_density) and show_points:
+        if (show_hist or show_density):
             cbar = plt.colorbar(fraction=0.046, pad=0.04)
             cbar.set_label("# points")
         plt.title(title)

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -257,7 +257,7 @@ def scatter(
         plt.grid(
             which="both", axis="both", linestyle=":", linewidth="0.2", color="grey"
         )
-        if show_hist or show_density:
+        if (show_hist or show_density) and show_points:
             cbar = plt.colorbar(fraction=0.046, pad=0.04)
             cbar.set_label("# points")
         plt.title(title)


### PR DESCRIPTION
Just a simple change in default scatter plots, I changed the default scatter plot from `2D Histogram` to `Points density`, so by default we would get:

`comparer.scatter(model=modname)`
![image](https://user-images.githubusercontent.com/97288080/192285925-ac7336b9-5e37-4f7f-b557-e1d7434168be.png)

Now 2D hist is not by default, so a kword show_hist must be included, then you get
`comparer.scatter(model=modname,show_hist=True)`
![image](https://user-images.githubusercontent.com/97288080/192286094-98b6f20b-83fa-4c75-bb13-bcee4d04c11b.png)

Also the number of points to be sampled for scatter plotting if the dataset is too large was increased from 10k to 50k.
No changes with respect to the default `cmap` yet

