### PR TITLE
Histogram default to density=True

### DIFF
--- a/fmskill/comparison.py
+++ b/fmskill/comparison.py
@@ -1495,7 +1495,9 @@ class SingleObsComparer(BaseComparer):
         plt.title(title)
         plt.xlabel(f"Residuals of {self._obs_unit_text}")
 
-    def hist(self, model=None, bins=100, title=None, alpha=0.5, **kwargs):
+    def hist(
+        self, *, model=None, bins=100, title=None, density=True, alpha=0.5, **kwargs
+    ):
         """Plot histogram of model data and observations.
 
         Wraps pandas.DataFrame hist() method.
@@ -1508,6 +1510,8 @@ class SingleObsComparer(BaseComparer):
             number of bins, by default 100
         title : str, optional
             plot title, default: [model name] vs [observation name]
+        density: bool, optional
+            If True, draw and return a probability density
         alpha : float, optional
             alpha transparency fraction, by default 0.5
         kwargs : other keyword arguments to df.hist()
@@ -1515,6 +1519,12 @@ class SingleObsComparer(BaseComparer):
         Returns
         -------
         matplotlib axes
+
+        See also
+        --------
+        pandas.Series.hist
+        matplotlib.axes.Axes.hist
+
         """
         mod_id = self._get_mod_id(model)
         mod_name = self.mod_names[mod_id]
@@ -1522,6 +1532,7 @@ class SingleObsComparer(BaseComparer):
         title = f"{mod_name} vs {self.name}" if title is None else title
 
         kwargs["alpha"] = alpha
+        kwargs["density"] = density
         ax = self.df[mod_name].hist(bins=bins, color=self._mod_colors[mod_id], **kwargs)
         self.df[self.obs_name].hist(
             bins=bins, color=self.observation.color, ax=ax, **kwargs
@@ -1529,6 +1540,11 @@ class SingleObsComparer(BaseComparer):
         ax.legend([mod_name, self.obs_name])
         plt.title(title)
         plt.xlabel(f"{self._obs_unit_text}")
+        if density:
+            plt.ylabel("density")
+        else:
+            plt.ylabel("count")
+
         return ax
 
 

--- a/fmskill/comparison.py
+++ b/fmskill/comparison.py
@@ -1926,6 +1926,7 @@ class ComparerCollection(Mapping, Sequence, BaseComparer):
         area: List[float] = None,
         df: pd.DataFrame = None,
         title: str = None,
+        density=True,
         alpha: float = 0.5,
         **kwargs,
     ):
@@ -1955,6 +1956,8 @@ class ComparerCollection(Mapping, Sequence, BaseComparer):
             user-provided data instead of the comparers own data, by default None
         title : str, optional
             plot title, default: observation name
+        density: bool, optional
+            If True, draw and return a probability density
         alpha : float, optional
             alpha transparency fraction, by default 0.5
         kwargs : other keyword arguments to df.hist()
@@ -1962,6 +1965,11 @@ class ComparerCollection(Mapping, Sequence, BaseComparer):
         Returns
         -------
         matplotlib axes
+
+        See also
+        --------
+        pandas.Series.hist
+        matplotlib.axes.Axes.hist
         """
         mod_id = self._get_mod_id(model)
         mod_name = self.mod_names[mod_id]
@@ -1983,11 +1991,18 @@ class ComparerCollection(Mapping, Sequence, BaseComparer):
         title = f"{mod_name} vs Observations" if title is None else title
 
         kwargs["alpha"] = alpha
+        kwargs["density"] = density
         ax = df.mod_val.hist(bins=bins, color=self[0]._mod_colors[mod_id], **kwargs)
         df.obs_val.hist(bins=bins, color=self[0].observation.color, ax=ax, **kwargs)
         ax.legend([mod_name, "observations"])
         plt.title(title)
         plt.xlabel(f"{self._obs_unit_text}")
+
+        if density:
+            plt.ylabel("density")
+        else:
+            plt.ylabel("count")
+
         return ax
 
     def mean_skill(

--- a/tests/test_pointobservation.py
+++ b/tests/test_pointobservation.py
@@ -70,7 +70,7 @@ def test_coordinates(klagshamn):
 def test_hist(klagshamn):
     o1 = PointObservation(klagshamn, item=0, x=366844, y=6154291, name="Klagshamn1")
     o1.hist()
-
+    o1.hist(density=False)
     o1.hist(bins=20, title="new_title", color="red")
 
 

--- a/tests/test_trackcompare.py
+++ b/tests/test_trackcompare.py
@@ -157,6 +157,7 @@ def test_hist(comparer):
     cc.hist(bins=np.linspace(0, 7, num=15))
 
     cc[0].hist(bins=10)
+    cc[0].hist(density=False)
     cc[0].hist(model=0, title="new_title", alpha=0.2)
     cc[0].residual_hist()
     cc[0].residual_hist(bins=10, title="new_title", color="blue")


### PR DESCRIPTION
The purpose of the `SingleObsComparer.hist()` and the `ComparerCollection.hist()` should be to compare distributions. not counts. The number of observations can be wildly different from the number of modelled data, which makes comparing counts pretty useless.

