### PR TITLE
Added missing case in unit display

### DIFF
--- a/fmskill/observation.py
+++ b/fmskill/observation.py
@@ -505,6 +505,6 @@ def unit_display_name(name: str) -> str:
     m
     """
 
-    res = name.replace("meter", "m").replace("_per_", "/").replace("second", "s").replace("sec", "s")
+    res = name.replace("meter", "m").replace("_per_", "/").replace(" per ", "/").replace("second", "s").replace("sec", "s")
 
     return res


### PR DESCRIPTION
only `_per_` in `meter_per_sec` was being corrected, but in some cases units were `meter per sec` and this was being missed, so I added ` per ` as well.