### PR TITLE
set plot style

### DIFF
--- a/fmskill/comparison.py
+++ b/fmskill/comparison.py
@@ -19,7 +19,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 from datetime import datetime, timedelta
 from copy import deepcopy
-
+import sys
 import mikeio
 import fmskill.metrics as mtr
 from .observation import PointObservation, TrackObservation
@@ -968,6 +968,9 @@ class BaseComparer:
 
         if title is None:
             title = f"{self.mod_names[mod_id]} vs {self.name}"
+        if sys.modules['fmskill'].plot_style=='MOOD' and skill_table==None:
+            #if MOOD and table ommited, then table
+            skill_table=True
 
         if skill_table != None:
             # Calculate Skill if it was requested to add as table on the right of plot

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -225,8 +225,8 @@ def scatter(
         plt.plot(
             [xlim[0], xlim[1]],
             [xlim[0], xlim[1]],
-            label="1:1",
-            c="blue",
+            label="1:1 Line (45°)",
+            c="darkorange",
             zorder=3,
         )
         if show_points:
@@ -238,33 +238,37 @@ def scatter(
                 x_sample,
                 y_sample,
                 c=c,
-                s=20,
-                alpha=0.5,
+                s=10,
+                alpha=0.9,
                 marker=".",
-                label=None,
+                label='Data',
                 zorder=1,
                 **kwargs,
             )
         plt.plot(
             xq,
             yq,
-            "X",
-            label="Q-Q",
-            c="darkturquoise",
-            markeredgecolor=(0, 0, 0, 0.4),
+            "o",
+            label="Quantiles (0.0 - 100.0%)",
+            c=(0,0,0,0),
+            markeredgecolor=(0,152/255,219/255),
+            markeredgewidth=1.2,
+            markersize=3.5,
             zorder=4,
         )
         plt.plot(
             x,
             intercept + slope * x,
-            "r",
+            "r--",
+            dashes=(2, 5),
+            c=(0,152/255,219/255),
             label=reglabel,
             zorder=2,
         )
         if show_hist:
             plt.hist2d(x, y, bins=nbins_hist, cmin=0.01, zorder=0.5, **kwargs)
 
-        plt.legend()
+        plt.legend(bbox_to_anchor=(1.6, 0.2),edgecolor='k')
         plt.xlabel(xlabel)
         plt.ylabel(ylabel)
         plt.axis("square")
@@ -534,7 +538,7 @@ def _plot_summary_table(skill_df,units,max_cbar):
         else:
             decimals=f'.{2}f'
         lines.append(
-            f"{(col.ljust(max_str_len)).upper()} {np.round(skill_df[col].values[0],2):{decimals}} {item_unit}"
+            f"{(col.ljust(max_str_len)).upper()} = {np.round(skill_df[col].values[0],2):{decimals}} {item_unit}"
                 )
 
     text_ = "\n".join(lines)
@@ -558,10 +562,9 @@ def _plot_summary_table(skill_df,units,max_cbar):
                 0.6,
                 text_,
                 bbox={
-                    "facecolor": "blue",
+                    "facecolor": "w",
                     "edgecolor": "k",
-                    "boxstyle": "round",
-                    "alpha": 0.05,
+                    "alpha": 0.99,
                 },
                 fontsize=12,
                 family="monospace",

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -268,7 +268,7 @@ def scatter(
         if show_hist:
             plt.hist2d(x, y, bins=nbins_hist, cmin=0.01, zorder=0.5, **kwargs)
 
-        plt.legend(bbox_to_anchor=(1.6, 0.2),edgecolor='k')
+        plt.legend(loc='center left',bbox_to_anchor=(1.2, 0.2),edgecolor='k')
         plt.xlabel(xlabel)
         plt.ylabel(ylabel)
         plt.axis("square")


### PR DESCRIPTION
Hi,

I would like to change the default matplotlib style for scatter plots in order to match other plots from DHI, as now fmskill looks too different.

This is how it looks now

![image](https://user-images.githubusercontent.com/97288080/207877829-809115ad-8b20-4e59-abdb-662549de9360.png)

And just by changing some line colors and sizes of markers and locations, I get this, which aligns with other tools (eg MOOD plots)
![image](https://user-images.githubusercontent.com/97288080/207877954-6fa652fb-27f4-44ed-b7af-e1ddba62abcf.png)

Still not 100% identical but quite almost there at least (both plots are different data by the way)