### PR TITLE
Added Skill Table if N_obs>1

### DIFF
--- a/fmskill/comparison.py
+++ b/fmskill/comparison.py
@@ -972,17 +972,14 @@ class BaseComparer:
         if skill_table != None:
             # Calculate Skill if it was requested to add as table on the right of plot
             if skill_table == True:
-                skill_df = self.skill(
-                    df=df, model=model, observation=observation, variable=variable
-                )
-            elif isinstance(skill_table, (list, tuple)):
-                skill_df = self.skill(
-                    df=df,
-                    metrics=skill_table,
-                    model=model,
-                    observation=observation,
-                    variable=variable,
-                )
+                if self.n_observations>1:
+                    skill_df = self.mean_skill(
+                        df=df, model=model, observation=observation, variable=variable
+                    )
+                else:
+                    skill_df = self.skill(
+                        df=df, model=model, observation=observation, variable=variable
+                    )
             # Check for units
             try:
                 units = unit_text.split("[")[1].split("]")[0]

--- a/fmskill/comparison.py
+++ b/fmskill/comparison.py
@@ -972,14 +972,15 @@ class BaseComparer:
         if skill_table != None:
             # Calculate Skill if it was requested to add as table on the right of plot
             if skill_table == True:
-                if self.n_observations>1:
-                    skill_df = self.mean_skill(
-                        df=df, model=model, observation=observation, variable=variable
-                    )
-                else:
+                if isinstance(self,PointComparer) or (isinstance(self, ComparerCollection) and self.n_observations==1):
                     skill_df = self.skill(
                         df=df, model=model, observation=observation, variable=variable
                     )
+                else: 
+                    skill_df = self.mean_skill(
+                        df=df, model=model, observation=observation, variable=variable
+                    )
+
             # Check for units
             try:
                 units = unit_text.split("[")[1].split("]")[0]

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -515,9 +515,6 @@ def _plot_summary_table(skill_df,units,max_cbar):
     stats_with_units=["bias", "rmse", "urmse", "mae"]
     max_str_len = skill_df.columns.str.len().max()
     lines = []
-    if len(skill_df)>1:
-        raise Exception('''`skill_table` kword can only be used for comparisons between 1 model and 1 measurement. 
-        Please add `model`, `variable` and `observation` kwords where required''')
 
     for col in skill_df.columns:
         if col == "model" or col == "variable":


### PR DESCRIPTION
Hi,

I just did a very small change as before plotting a scatter with `skill_table` was only allowed for 1 observation vs the model.
Now it works for `n` number of observations with `n>=1` , and in this case the skill_table will be `cc.mean_skill()`


Example of skill table with 1 observation
---
![image](https://user-images.githubusercontent.com/97288080/208676794-f1415aff-61c5-4d2b-8fc3-fd6e972984f4.png)

Example of skill table with n>1 observations
---
![image](https://user-images.githubusercontent.com/97288080/208676868-f04ab5bb-9fd3-4eb7-be69-d6a2f73dde13.png)


This is a very powerful tool of fmskill (the `mean_skill`) and I changed nothing in it, just added the option to put it in a scatter plot.
