### PR TITLE
package-wide options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,7 +131,7 @@ dmypy.json
 
 /data/
 tests/testdata/tmp
-
+/tmp/
 
 # ignore .bak files
 *.bak

--- a/fmskill/__init__.py
+++ b/fmskill/__init__.py
@@ -26,7 +26,7 @@ if "64" not in architecture()[0]:
 from .model.factory import ModelResult
 from .observation import PointObservation, TrackObservation
 from .connection import compare, Connector
-from .settings import options
+from .settings import options, get_option, set_option, reset_option
 
 
 def from_config(

--- a/fmskill/__init__.py
+++ b/fmskill/__init__.py
@@ -27,6 +27,14 @@ from .model.factory import ModelResult
 from .observation import PointObservation, TrackObservation
 from .connection import compare, Connector
 
+from .settings import (
+    get_option,
+    set_option,
+    reset_option,
+    describe_option,
+    options,
+)
+
 
 def from_config(
     configuration: Union[dict, str], *, validate_eum=True, relative_path=True

--- a/fmskill/__init__.py
+++ b/fmskill/__init__.py
@@ -26,14 +26,7 @@ if "64" not in architecture()[0]:
 from .model.factory import ModelResult
 from .observation import PointObservation, TrackObservation
 from .connection import compare, Connector
-
-from .settings import (
-    get_option,
-    set_option,
-    reset_option,
-    describe_option,
-    options,
-)
+from .settings import options
 
 
 def from_config(

--- a/fmskill/comparison.py
+++ b/fmskill/comparison.py
@@ -26,9 +26,9 @@ from .observation import PointObservation, TrackObservation
 from .plot import scatter, taylor_diagram, TaylorPoint
 from .skill import AggregatedSkill
 from .spatial import SpatialSkill
+from .settings import options
 
-
-DEFAULT_METRICS = [mtr.bias, mtr.rmse, mtr.urmse, mtr.mae, mtr.cc, mtr.si, mtr.r2]
+# DEFAULT_METRICS = [mtr.bias, mtr.rmse, mtr.urmse, mtr.mae, mtr.cc, mtr.si, mtr.r2]
 
 
 class BaseComparer:
@@ -100,7 +100,7 @@ class BaseComparer:
     @metrics.setter
     def metrics(self, values) -> None:
         if values is None:
-            self._metrics = DEFAULT_METRICS
+            self._metrics = options.metrics.default
         else:
             self._metrics = self._parse_metric(values)
 
@@ -178,7 +178,7 @@ class BaseComparer:
 
     def __init__(self, observation, modeldata=None):
 
-        self._metrics = DEFAULT_METRICS
+        self._metrics = options.metrics.default
         self.obs_name = "Observation"
         self._obs_names: List[str]
         self._mod_names: List[str]
@@ -1828,7 +1828,7 @@ class ComparerCollection(Mapping, Sequence, BaseComparer):
 
     def __init__(self):
         # super().__init__(observation=None, modeldata=None)  # Not possible since init signature is different compared to BaseComparer
-        self._metrics = DEFAULT_METRICS
+        self._metrics = options.metrics.default
         self._all_df = None
         self._start = datetime(2900, 1, 1)
         self._end = datetime(1, 1, 1)

--- a/fmskill/comparison.py
+++ b/fmskill/comparison.py
@@ -28,12 +28,15 @@ from .skill import AggregatedSkill
 from .spatial import SpatialSkill
 from .settings import options, register_option
 
-# DEFAULT_METRICS = [mtr.bias, mtr.rmse, mtr.urmse, mtr.mae, mtr.cc, mtr.si, mtr.r2]
-
 register_option(
-    "metrics.default",
+    "metrics.primary",
+    mtr.rmse,
+    doc="Default metric in cases where a only a single metric can be reported.",
+)
+register_option(
+    "metrics.list",
     [mtr.bias, mtr.rmse, mtr.urmse, mtr.mae, mtr.cc, mtr.si, mtr.r2],
-    doc="Default metrics to be used in skill tables if specific metrics are not described.",
+    doc="Default metrics list to be used in skill tables if specific metrics are not provided.",
 )
 
 
@@ -106,7 +109,7 @@ class BaseComparer:
     @metrics.setter
     def metrics(self, values) -> None:
         if values is None:
-            self._metrics = options.metrics.default
+            self._metrics = options.metrics.list
         else:
             self._metrics = self._parse_metric(values)
 
@@ -184,7 +187,7 @@ class BaseComparer:
 
     def __init__(self, observation, modeldata=None):
 
-        self._metrics = options.metrics.default
+        self._metrics = options.metrics.list
         self.obs_name = "Observation"
         self._obs_names: List[str]
         self._mod_names: List[str]
@@ -401,7 +404,7 @@ class BaseComparer:
             e.g.: 'freq:M' = monthly; 'freq:D' daily
             by default ["model","observation"]
         metrics : list, optional
-            list of fmskill.metrics, by default [bias, rmse, urmse, mae, cc, si, r2]
+            list of fmskill.metrics, by default fmskill.options.metrics.list
         model : (str, int, List[str], List[int]), optional
             name or ids of models to be compared, by default all
         observation : (str, int, List[str], List[int])), optional
@@ -585,7 +588,7 @@ class BaseComparer:
             e.g.: 'freq:M' = monthly; 'freq:D' daily
             by default ["model","observation"]
         metrics : list, optional
-            list of fmskill.metrics, by default [bias, rmse, urmse, mae, cc, si, r2]
+            list of fmskill.metrics, by default fmskill.options.metrics.list
         n_min : int, optional
             minimum number of observations in a grid cell;
             cells with fewer observations get a score of `np.nan`
@@ -924,7 +927,7 @@ class BaseComparer:
         df : pd.dataframe, optional
             show user-provided data instead of the comparers own data, by default None
         skill_table : str, List[str], bool, optional
-            list of fmskill.metrics or boolean, if True then by default [bias, rmse, urmse, mae, cc, si, r2].
+            list of fmskill.metrics or boolean, if True then by default fmskill.options.metrics.list.
             This kword adds a box at the right of the scatter plot,
             by default False
         kwargs
@@ -1195,7 +1198,7 @@ class SingleObsComparer(BaseComparer):
             e.g.: 'freq:M' = monthly; 'freq:D' daily
             by default ["model"]
         metrics : list, optional
-            list of fmskill.metrics, by default [bias, rmse, urmse, mae, cc, si, r2]
+            list of fmskill.metrics, by default fmskill.options.metrics.list
         model : (str, int, List[str], List[int]), optional
             name or ids of models to be compared, by default all
         freq : string, optional
@@ -1834,7 +1837,7 @@ class ComparerCollection(Mapping, Sequence, BaseComparer):
 
     def __init__(self, comparers=None):
         # super().__init__(observation=None, modeldata=None)  # Not possible since init signature is different compared to BaseComparer
-        self._metrics = options.metrics.default
+        self._metrics = options.metrics.list
         self._all_df = None
         self._start = datetime(2900, 1, 1)
         self._end = datetime(1, 1, 1)
@@ -2047,7 +2050,7 @@ class ComparerCollection(Mapping, Sequence, BaseComparer):
             dictionary of observations with special weigths, others will be set to 1.0
             by default None (i.e. observations weight attribute if assigned else "equal")
         metrics : list, optional
-            list of fmskill.metrics, by default [bias, rmse, urmse, mae, cc, si, r2]
+            list of fmskill.metrics, by default fmskill.options.metrics.list
         model : (str, int, List[str], List[int]), optional
             name or ids of models to be compared, by default all
         observation : (str, int, List[str], List[int])), optional
@@ -2162,7 +2165,7 @@ class ComparerCollection(Mapping, Sequence, BaseComparer):
         Parameters
         ----------
         metrics : list, optional
-            list of fmskill.metrics, by default [bias, rmse, urmse, mae, cc, si, r2]
+            list of fmskill.metrics, by default fmskill.options.metrics.list
         model : (str, int, List[str], List[int]), optional
             name or ids of models to be compared, by default all
         observation : (str, int, List[str], List[int])), optional

--- a/fmskill/comparison.py
+++ b/fmskill/comparison.py
@@ -26,9 +26,15 @@ from .observation import PointObservation, TrackObservation
 from .plot import scatter, taylor_diagram, TaylorPoint
 from .skill import AggregatedSkill
 from .spatial import SpatialSkill
-from .settings import options
+from .settings import options, register_option
 
 # DEFAULT_METRICS = [mtr.bias, mtr.rmse, mtr.urmse, mtr.mae, mtr.cc, mtr.si, mtr.r2]
+
+register_option(
+    "metrics.default",
+    [mtr.bias, mtr.rmse, mtr.urmse, mtr.mae, mtr.cc, mtr.si, mtr.r2],
+    doc="Default metrics to be used in skill tables if specific metrics are not described.",
+)
 
 
 class BaseComparer:
@@ -972,11 +978,13 @@ class BaseComparer:
         if skill_table != None:
             # Calculate Skill if it was requested to add as table on the right of plot
             if skill_table == True:
-                if isinstance(self,PointComparer) or (isinstance(self, ComparerCollection) and self.n_observations==1):
+                if isinstance(self, PointComparer) or (
+                    isinstance(self, ComparerCollection) and self.n_observations == 1
+                ):
                     skill_df = self.skill(
                         df=df, model=model, observation=observation, variable=variable
                     )
-                else: 
+                else:
                     skill_df = self.mean_skill(
                         df=df, model=model, observation=observation, variable=variable
                     )

--- a/fmskill/comparison.py
+++ b/fmskill/comparison.py
@@ -26,13 +26,13 @@ from .observation import PointObservation, TrackObservation
 from .plot import scatter, taylor_diagram, TaylorPoint
 from .skill import AggregatedSkill
 from .spatial import SpatialSkill
-from .settings import options, register_option
+from .settings import options, register_option, reset_option
 
-register_option(
-    "metrics.primary",
-    mtr.rmse,
-    doc="Default metric in cases where a only a single metric can be reported.",
-)
+# register_option(
+#     "metrics.primary",
+#     mtr.rmse,
+#     doc="Default metric in cases where a only a single metric can be reported.",
+# )
 register_option(
     "metrics.list",
     [mtr.bias, mtr.rmse, mtr.urmse, mtr.mae, mtr.cc, mtr.si, mtr.r2],
@@ -104,14 +104,14 @@ class BaseComparer:
 
     @property
     def metrics(self):
-        return self._metrics
+        return options.metrics.list
 
     @metrics.setter
     def metrics(self, values) -> None:
         if values is None:
-            self._metrics = options.metrics.list
+            reset_option("metrics.list")
         else:
-            self._metrics = self._parse_metric(values)
+            options.metrics.list = self._parse_metric(values)
 
     def __add__(self, other: "BaseComparer") -> "ComparerCollection":
 
@@ -187,7 +187,7 @@ class BaseComparer:
 
     def __init__(self, observation, modeldata=None):
 
-        self._metrics = options.metrics.list
+        # self._metrics = options.metrics.list
         self.obs_name = "Observation"
         self._obs_names: List[str]
         self._mod_names: List[str]
@@ -357,7 +357,7 @@ class BaseComparer:
 
     def _parse_metric(self, metric, return_list=False):
         if metric is None:
-            return self._metrics
+            metric = self.metrics
 
         if isinstance(metric, str):
             valid_metrics = [
@@ -1837,7 +1837,7 @@ class ComparerCollection(Mapping, Sequence, BaseComparer):
 
     def __init__(self, comparers=None):
         # super().__init__(observation=None, modeldata=None)  # Not possible since init signature is different compared to BaseComparer
-        self._metrics = options.metrics.list
+        # self._metrics = options.metrics.list
         self._all_df = None
         self._start = datetime(2900, 1, 1)
         self._end = datetime(1, 1, 1)

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -11,6 +11,7 @@ import mikeio
 from .observation import Observation, PointObservation, TrackObservation
 from .metrics import _linear_regression
 from .plot_taylor import TaylorDiagram
+from .settings import options
 
 
 def scatter(
@@ -90,10 +91,9 @@ def scatter(
         user default units to override default units, eg 'metre', by default None
     kwargs
     """
-    if show_hist==None and show_density==None:
-        #Default: points density
-        show_density=True
-
+    if show_hist == None and show_density == None:
+        # Default: points density
+        show_density = True
 
     if (binsize is not None) or (nbins is not None):
         warnings.warn(
@@ -184,14 +184,14 @@ def scatter(
         # if not an int nor None, it must be a squence of floats
         xq = np.quantile(x, q=quantiles)
         yq = np.quantile(y, q=quantiles)
-    
+
     if show_hist:
-        #if histogram is wanted (explicit non-default flag) then density is off
+        # if histogram is wanted (explicit non-default flag) then density is off
         if show_density == True:
             raise TypeError(
                 "if `show_hist=True` then `show_density` must be either `False` or `None`"
-            )        
-        
+            )
+
     if show_density:
         if not ((type(bins) == float) or (type(bins) == int)):
             raise TypeError(
@@ -201,7 +201,7 @@ def scatter(
         if show_hist == True:
             raise TypeError(
                 "if `show_density=True` then `show_hist` must be either `False` or `None`"
-            )    
+            )
         # calculate density data
         z = _scatter_density(x_sample, y_sample, binsize=binsize)
         idx = z.argsort()
@@ -238,7 +238,7 @@ def scatter(
                 x_sample,
                 y_sample,
                 c=c,
-                s=20,
+                s=options.plot.scatter.point_size,
                 alpha=0.5,
                 marker=".",
                 label=None,
@@ -274,18 +274,17 @@ def scatter(
         plt.grid(
             which="both", axis="both", linestyle=":", linewidth="0.2", color="grey"
         )
-        max_cbar=None
-        if (show_hist or (show_density and show_points)):
+        max_cbar = None
+        if show_hist or (show_density and show_points):
             cbar = plt.colorbar(fraction=0.046, pad=0.04)
             ticks = cbar.ax.get_yticks()
-            max_cbar=ticks[-1]
-            cbar.set_label("# points")        
-            
+            max_cbar = ticks[-1]
+            cbar.set_label("# points")
+
         plt.title(title)
         # Add skill table
         if skill_df != None:
-            _plot_summary_table(skill_df,units,max_cbar=max_cbar)
-        
+            _plot_summary_table(skill_df, units, max_cbar=max_cbar)
 
     elif backend == "plotly":  # pragma: no cover
         import plotly.graph_objects as go
@@ -511,58 +510,61 @@ def _scatter_density(x, y, binsize: float = 0.1, method: str = "linear"):
 
     return Z_grid
 
-def _plot_summary_table(skill_df,units,max_cbar):
-    stats_with_units=["bias", "rmse", "urmse", "mae"]
+
+def _plot_summary_table(skill_df, units, max_cbar):
+    stats_with_units = ["bias", "rmse", "urmse", "mae"]
     max_str_len = skill_df.columns.str.len().max()
     lines = []
-    if len(skill_df)>1:
-        raise Exception('''`skill_table` kword can only be used for comparisons between 1 model and 1 measurement. 
-        Please add `model`, `variable` and `observation` kwords where required''')
+    if len(skill_df) > 1:
+        raise Exception(
+            """`skill_table` kword can only be used for comparisons between 1 model and 1 measurement. 
+        Please add `model`, `variable` and `observation` kwords where required"""
+        )
 
     for col in skill_df.columns:
         if col == "model" or col == "variable":
             continue
         if col in stats_with_units:
-            #if statistic has dimensions, then add units
-            item_unit=units
+            # if statistic has dimensions, then add units
+            item_unit = units
         else:
-            #else, add empty space (for fomatting)
-            item_unit=' '
-        if col=="n":
+            # else, add empty space (for fomatting)
+            item_unit = " "
+        if col == "n":
             # Number of samples, integer, else, 2 decimals
-            decimals=f'.{0}f'
+            decimals = f".{0}f"
         else:
-            decimals=f'.{2}f'
+            decimals = f".{2}f"
         lines.append(
             f"{(col.ljust(max_str_len)).upper()} {np.round(skill_df[col].values[0],2):{decimals}} {item_unit}"
-                )
+        )
 
     text_ = "\n".join(lines)
 
-    if max_cbar==None:
-        x=0.93
-    elif max_cbar<1e3:
-        x=0.99
-    elif max_cbar<1e4:
-        x=1.01
-    elif max_cbar<1e5:
-        x=1.03
-    elif max_cbar<1e6:
-        x=1.05
+    if max_cbar == None:
+        x = 0.93
+    elif max_cbar < 1e3:
+        x = 0.99
+    elif max_cbar < 1e4:
+        x = 1.01
+    elif max_cbar < 1e5:
+        x = 1.03
+    elif max_cbar < 1e6:
+        x = 1.05
     else:
-        #When more than 1e6 samples, matplotlib changes to scientific notation
-        x=0.97
+        # When more than 1e6 samples, matplotlib changes to scientific notation
+        x = 0.97
 
     plt.gcf().text(
-                x,
-                0.6,
-                text_,
-                bbox={
-                    "facecolor": "blue",
-                    "edgecolor": "k",
-                    "boxstyle": "round",
-                    "alpha": 0.05,
-                },
-                fontsize=12,
-                family="monospace",
-            )
+        x,
+        0.6,
+        text_,
+        bbox={
+            "facecolor": "blue",
+            "edgecolor": "k",
+            "boxstyle": "round",
+            "alpha": 0.05,
+        },
+        fontsize=12,
+        family="monospace",
+    )

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -36,8 +36,8 @@ def is_between_0_and_1(value: object) -> None:
 register_option("plot.scatter.points.size", 20, validator=is_positive)
 register_option("plot.scatter.points.alpha", 0.5, validator=is_between_0_and_1)
 register_option("plot.scatter.points.label", "", validator=settings.is_str)
-register_option("plot.scatter.quantiles.size", 3.5, validator=is_positive)
 register_option("plot.scatter.quantiles.marker", "X", validator=settings.is_str)
+register_option("plot.scatter.quantiles.markersize", 3.5, validator=is_positive)
 register_option(
     "plot.scatter.quantiles.color", "darkturquoise", validator=settings.is_str
 )
@@ -288,6 +288,7 @@ def scatter(
             c=options.plot.scatter.quantiles.color,
             zorder=4,
             markeredgecolor=options.plot.scatter.quantiles.markeredgecolor,
+            markersize=options.plot.scatter.quantiles.markersize,
         )
         plt.plot(
             x,

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -15,34 +15,17 @@ import fmskill.settings as settings
 from .settings import options, register_option
 
 
-def is_positive(value: object) -> None:
-    if np.isreal(value) and value > 0:
-        return
-    raise ValueError("Value must be a number greater than 0")
-
-
-def is_nonnegative(value: object) -> None:
-    if np.isreal(value) and value >= 0:
-        return
-    raise ValueError("Value must be a non-negative number")
-
-
-def is_between_0_and_1(value: object) -> None:
-    if np.isreal(value) and value >= 0 and value <= 1:
-        return
-    raise ValueError("Value must be a number between 0 and 1")
-
-
-register_option("plot.scatter.points.size", 20, validator=is_positive)
-register_option("plot.scatter.points.alpha", 0.5, validator=is_between_0_and_1)
+register_option("plot.scatter.points.size", 20, validator=settings.is_positive)
+register_option("plot.scatter.points.alpha", 0.5, validator=settings.is_between_0_and_1)
 register_option("plot.scatter.points.label", "", validator=settings.is_str)
 register_option("plot.scatter.quantiles.marker", "X", validator=settings.is_str)
-register_option("plot.scatter.quantiles.markersize", 3.5, validator=is_positive)
+register_option("plot.scatter.quantiles.markersize", 3.5, validator=settings.is_positive)
 register_option(
     "plot.scatter.quantiles.color", "darkturquoise", validator=settings.is_str
 )
 register_option("plot.scatter.quantiles.label", "Q-Q", validator=settings.is_str)
 register_option("plot.scatter.quantiles.markeredgecolor", (0, 0, 0, 0.4))
+register_option("plot.scatter.quantiles.kwargs", {}, settings.is_dict)
 register_option("plot.scatter.oneone_line.label", "1:1", validator=settings.is_str)
 register_option("plot.scatter.oneone_line.color", "blue", validator=settings.is_str)
 register_option("plot.scatter.reg_line.color", "r", validator=settings.is_str)
@@ -289,6 +272,7 @@ def scatter(
             zorder=4,
             markeredgecolor=options.plot.scatter.quantiles.markeredgecolor,
             markersize=options.plot.scatter.quantiles.markersize,
+            **settings.get_option("plot.scatter.quantiles.kwargs")
         )
         plt.plot(
             x,

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -11,7 +11,12 @@ import mikeio
 from .observation import Observation, PointObservation, TrackObservation
 from .metrics import _linear_regression
 from .plot_taylor import TaylorDiagram
-from .settings import options
+import fmskill.settings as settings
+from .settings import options, register_option
+
+
+register_option("plot.font.color", "red", validator=settings.is_str)
+register_option("plot.scatter.point_size", 10, validator=settings.is_int)
 
 
 def scatter(

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -36,20 +36,17 @@ def is_between_0_and_1(value: object) -> None:
 register_option("plot.scatter.points.size", 20, validator=is_positive)
 register_option("plot.scatter.points.alpha", 0.5, validator=is_between_0_and_1)
 register_option("plot.scatter.points.label", "", validator=settings.is_str)
-register_option("plot.scatter.points.plot_kwargs", {})
 register_option("plot.scatter.quantiles.size", 3.5, validator=is_positive)
 register_option("plot.scatter.quantiles.marker", "X", validator=settings.is_str)
-register_option("plot.scatter.quantiles.color", "darkturquoise")
-register_option("plot.scatter.quantiles.label", "Q-Q", validator=settings.is_str)
 register_option(
-    "plot.scatter.quantiles.plot_kwargs", {"markeredgecolor": (0, 0, 0, 0.4)}
+    "plot.scatter.quantiles.color", "darkturquoise", validator=settings.is_str
 )
-register_option("plot.scatter.reg_line.label", "1:1", validator=settings.is_str)
+register_option("plot.scatter.quantiles.label", "Q-Q", validator=settings.is_str)
+register_option("plot.scatter.quantiles.markeredgecolor", (0, 0, 0, 0.4))
+register_option("plot.scatter.oneone_line.label", "1:1", validator=settings.is_str)
+register_option("plot.scatter.oneone_line.color", "blue", validator=settings.is_str)
 register_option("plot.scatter.reg_line.color", "r", validator=settings.is_str)
-register_option("plot.scatter.reg_line.plot_kwargs", {})
-register_option("plot.scatter.legend_kwargs", {})
-register_option("plot.scatter.table.show", False, validator=settings.is_bool)
-register_option("plot.scatter.table.bbox_kwargs", {})
+# register_option("plot.scatter.table.show", False, validator=settings.is_bool)
 
 
 def scatter(
@@ -263,8 +260,8 @@ def scatter(
         plt.plot(
             [xlim[0], xlim[1]],
             [xlim[0], xlim[1]],
-            label="1:1",
-            c="blue",
+            label=options.plot.scatter.oneone_line.label,
+            c=options.plot.scatter.oneone_line.color,
             zorder=3,
         )
         if show_points:
@@ -276,26 +273,26 @@ def scatter(
                 x_sample,
                 y_sample,
                 c=c,
-                s=options.plot.scatter.point_size,
-                alpha=0.5,
+                s=options.plot.scatter.points.size,
+                alpha=options.plot.scatter.points.alpha,
                 marker=".",
-                label=None,
+                label=options.plot.scatter.points.label,
                 zorder=1,
                 **kwargs,
             )
         plt.plot(
             xq,
             yq,
-            "X",
-            label="Q-Q",
-            c="darkturquoise",
-            markeredgecolor=(0, 0, 0, 0.4),
+            options.plot.scatter.quantiles.marker,
+            label=options.plot.scatter.quantiles.label,
+            c=options.plot.scatter.quantiles.color,
             zorder=4,
+            markeredgecolor=options.plot.scatter.quantiles.markeredgecolor,
         )
         plt.plot(
             x,
             intercept + slope * x,
-            "r",
+            options.plot.scatter.reg_line.color,
             label=reglabel,
             zorder=2,
         )
@@ -378,10 +375,10 @@ def scatter(
             go.Scatter(
                 x=xq,
                 y=yq,
-                name="Q-Q",
+                name=options.plot.scatter.quantiles.label,
                 mode="markers",
                 marker_symbol="x",
-                marker_color="darkturquoise",
+                marker_color=options.plot.scatter.quantiles.color,
                 marker_line_color="midnightblue",
                 marker_line_width=0.6,
             )

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -15,8 +15,41 @@ import fmskill.settings as settings
 from .settings import options, register_option
 
 
-register_option("plot.font.color", "red", validator=settings.is_str)
-register_option("plot.scatter.point_size", 10, validator=settings.is_int)
+def is_positive(value: object) -> None:
+    if np.isreal(value) and value > 0:
+        return
+    raise ValueError("Value must be a number greater than 0")
+
+
+def is_nonnegative(value: object) -> None:
+    if np.isreal(value) and value >= 0:
+        return
+    raise ValueError("Value must be a non-negative number")
+
+
+def is_between_0_and_1(value: object) -> None:
+    if np.isreal(value) and value >= 0 and value <= 1:
+        return
+    raise ValueError("Value must be a number between 0 and 1")
+
+
+register_option("plot.scatter.points.size", 20, validator=is_positive)
+register_option("plot.scatter.points.alpha", 0.5, validator=is_between_0_and_1)
+register_option("plot.scatter.points.label", "", validator=settings.is_str)
+register_option("plot.scatter.points.plot_kwargs", {})
+register_option("plot.scatter.quantiles.size", 3.5, validator=is_positive)
+register_option("plot.scatter.quantiles.marker", "X", validator=settings.is_str)
+register_option("plot.scatter.quantiles.color", "darkturquoise")
+register_option("plot.scatter.quantiles.label", "Q-Q", validator=settings.is_str)
+register_option(
+    "plot.scatter.quantiles.plot_kwargs", {"markeredgecolor": (0, 0, 0, 0.4)}
+)
+register_option("plot.scatter.reg_line.label", "1:1", validator=settings.is_str)
+register_option("plot.scatter.reg_line.color", "r", validator=settings.is_str)
+register_option("plot.scatter.reg_line.plot_kwargs", {})
+register_option("plot.scatter.legend_kwargs", {})
+register_option("plot.scatter.table.show", False, validator=settings.is_bool)
+register_option("plot.scatter.table.bbox_kwargs", {})
 
 
 def scatter(

--- a/fmskill/settings.py
+++ b/fmskill/settings.py
@@ -1,0 +1,446 @@
+"""
+The settings module holds package-wide configurables and provides
+a uniform API for working with them.
+
+This module is heavily inspired by pandas config module
+https://github.com/pandas-dev/pandas/tree/main/pandas/_config 
+
+Overview
+========
+This module supports the following requirements:
+- options are referenced using keys in dot.notation, e.g. "x.y.option - z".
+- keys are case-insensitive.
+- functions should accept partial/regex keys, when unambiguous.
+- options can be registered by modules at import time.
+- options have a default value, and (optionally) a description and
+  validation function associated with them.
+- options can be reset to their default value.
+- all option can be reset to their default value at once.
+- all options in a certain sub - namespace can be reset at once.
+- the user can set / get / reset or ask for the description of an option.
+- a developer can register an option.
+
+Implementation
+==============
+- Data is stored using nested dictionaries, and should be accessed
+  through the provided API.
+- "Registered options" have metadata associated
+  with them, which are stored in auxiliary dictionaries keyed on the
+  fully-qualified key, e.g. "x.y.z.option".
+
+"""
+import re
+from typing import Any, Callable, Iterable, NamedTuple
+import warnings
+import fmskill.metrics as mtr
+
+
+class RegisteredOption(NamedTuple):
+    key: str
+    defval: object
+    doc: str
+    validator: Callable[[object], Any] | None
+    cb: Callable[[str], Any] | None
+
+
+# holds registered option metadata
+_registered_options: dict[str, RegisteredOption] = {}
+
+# holds the current values for registered options
+_global_settings: dict[str, Any] = {}
+
+
+class OptionError(AttributeError, KeyError):
+    pass
+
+
+def _get_single_key(pat: str) -> str:
+    keys = _select_options(pat)
+    if len(keys) == 0:
+        raise OptionError(f"No such keys(s): {repr(pat)}")
+    if len(keys) > 1:
+        raise OptionError("Pattern matched multiple keys")
+    key = keys[0]
+
+    # key = _translate_key(key)  # deprecated keys
+
+    return key
+
+
+def _get_option(pat: str) -> Any:
+    key = _get_single_key(pat)
+
+    # walk the nested dict
+    root, k = _get_root(key)
+    return root[k]
+
+
+def _set_option(*args, **kwargs) -> None:
+    # must at least 1 arg deal with constraints later
+    nargs = len(args)
+    if not nargs or nargs % 2 != 0:
+        raise ValueError("Must provide an even number of non-keyword arguments")
+
+    # default to false
+    silent = kwargs.pop("silent", False)
+
+    if kwargs:
+        kwarg = list(kwargs.keys())[0]
+        raise TypeError(f'_set_option() got an unexpected keyword argument "{kwarg}"')
+
+    for k, v in zip(args[::2], args[1::2]):
+        key = _get_single_key(k)  # , silent)
+
+        o = _get_registered_option(key)
+        if o and o.validator:
+            o.validator(v)
+
+        # walk the nested dict
+        root, k = _get_root(key)
+        root[k] = v
+
+        if o.cb:
+            if silent:
+                with warnings.catch_warnings(record=True):
+                    o.cb(key)
+            else:
+                o.cb(key)
+
+
+def _describe_option_short(pat: str = "", _print_desc: bool = True) -> str | None:
+
+    keys = _select_options(pat)
+    if len(keys) == 0:
+        raise OptionError("No such keys(s)")
+
+    s = "\n".join([f"{k} : {_get_option(k)}" for k in keys])
+
+    if _print_desc:
+        print(s)
+        return None
+    return s
+
+
+def _describe_option(pat: str = "", _print_desc: bool = True) -> str | None:
+
+    keys = _select_options(pat)
+    if len(keys) == 0:
+        raise OptionError("No such keys(s)")
+
+    s = "\n".join([_build_option_description(k) for k in keys])
+
+    if _print_desc:
+        print(s)
+        return None
+    return s
+
+
+def _reset_option(pat: str, silent: bool = False) -> None:
+
+    keys = _select_options(pat)
+
+    if len(keys) == 0:
+        raise OptionError("No such keys(s)")
+
+    if len(keys) > 1 and len(pat) < 4 and pat != "all":
+        raise ValueError(
+            "You must specify at least 4 characters when "
+            "resetting multiple keys, use the special keyword "
+            '"all" to reset all the options to their default value'
+        )
+
+    for k in keys:
+        _set_option(k, _registered_options[k].defval, silent=silent)
+
+
+def get_default_val(pat: str):
+    key = _get_single_key(pat, silent=True)
+    return _get_registered_option(key).defval
+
+
+class DictWrapper:
+    """provide attribute-style access to a nested dict"""
+
+    def __init__(self, d: dict[str, Any], prefix: str = "") -> None:
+        object.__setattr__(self, "d", d)
+        object.__setattr__(self, "prefix", prefix)
+
+    def __setattr__(self, key: str, val: Any) -> None:
+        prefix = object.__getattribute__(self, "prefix")
+        if prefix:
+            prefix += "."
+        prefix += key
+        # you can't set new keys
+        # can you can't overwrite subtrees
+        if key in self.d and not isinstance(self.d[key], dict):
+            _set_option(prefix, val)
+        else:
+            raise OptionError("You can only set the value of existing options")
+
+    def __getattr__(self, key: str):
+        prefix = object.__getattribute__(self, "prefix")
+        if prefix:
+            prefix += "."
+        prefix += key
+        try:
+            v = object.__getattribute__(self, "d")[key]
+        except KeyError as err:
+            raise OptionError("No such option") from err
+        if isinstance(v, dict):
+            return DictWrapper(v, prefix)
+        else:
+            return _get_option(prefix)
+
+    def __repr__(self) -> str:
+        return _describe_option_short(self.prefix, False)
+        # return yaml.dump(self.d, sort_keys=False)
+
+    def __dir__(self) -> Iterable[str]:
+        return list(self.d.keys())
+
+
+def _select_options(pat: str) -> list[str]:
+    """
+    returns a list of keys matching `pat`
+    if pat=="all", returns all registered options
+    """
+    # short-circuit for exact key
+    if pat in _registered_options:
+        return [pat]
+
+    # else look through all of them
+    keys = sorted(_registered_options.keys())
+    if pat == "all":  # reserved key
+        return keys
+
+    return [k for k in keys if re.search(pat, k, re.I)]
+
+
+def _get_root(key: str) -> tuple[dict[str, Any], str]:
+    path = key.split(".")
+    cursor = _global_settings
+    for p in path[:-1]:
+        cursor = cursor[p]
+    return cursor, path[-1]
+
+
+def _get_registered_option(key: str):
+    """
+    Retrieves the option metadata if `key` is a registered option.
+    Returns
+    -------
+    RegisteredOption (namedtuple) if key is deprecated, None otherwise
+    """
+    return _registered_options.get(key)
+
+
+def _build_option_description(k: str) -> str:
+    """Builds a formatted description of a registered option and prints it"""
+    o = _get_registered_option(k)
+
+    s = f"{k} "
+
+    if o.doc:
+        s += "\n".join(o.doc.strip().split("\n"))
+    else:
+        s += "No description available."
+
+    if o:
+        s += f"\n    [default: {o.defval}] [currently: {_get_option(k)}]"
+
+    return s
+
+
+get_option = _get_option
+set_option = _set_option
+reset_option = _reset_option
+describe_option = _describe_option
+options = DictWrapper(_global_settings)
+
+
+def register_option(
+    key: str,
+    defval: object,
+    doc: str = "",
+    validator: Callable[[object], Any] | None = None,
+    cb: Callable[[str], Any] | None = None,
+) -> None:
+    """
+    Register an option in the package-wide pandas config object
+    Parameters
+    ----------
+    key : str
+        Fully-qualified key, e.g. "x.y.option - z".
+    defval : object
+        Default value of the option.
+    doc : str
+        Description of the option.
+    validator : Callable, optional
+        Function of a single argument, should raise `ValueError` if
+        called with a value which is not a legal value for the option.
+    cb
+        a function of a single argument "key", which is called
+        immediately after an option value is set/reset. key is
+        the full name of the option.
+    Raises
+    ------
+    ValueError if `validator` is specified and `defval` is not a valid value.
+    """
+    import keyword
+    import tokenize
+
+    key = key.lower()
+
+    if key in _registered_options:
+        raise OptionError(f"Option '{key}' has already been registered")
+    # if key in _reserved_keys:
+    #     raise OptionError(f"Option '{key}' is a reserved key")
+
+    # the default value should be legal
+    if validator:
+        validator(defval)
+
+    # walk the nested dict, creating dicts as needed along the path
+    path = key.split(".")
+
+    for k in path:
+        if not re.match("^" + tokenize.Name + "$", k):
+            raise ValueError(f"{k} is not a valid identifier")
+        if keyword.iskeyword(k):
+            raise ValueError(f"{k} is a python keyword")
+
+    cursor = _global_settings
+    msg = "Path prefix to option '{option}' is already an option"
+
+    for i, p in enumerate(path[:-1]):
+        if not isinstance(cursor, dict):
+            raise OptionError(msg.format(option=".".join(path[:i])))
+        if p not in cursor:
+            cursor[p] = {}
+        cursor = cursor[p]
+
+    if not isinstance(cursor, dict):
+        raise OptionError(msg.format(option=".".join(path[:-1])))
+
+    cursor[path[-1]] = defval  # initialize
+
+    # save the option metadata
+    _registered_options[key] = RegisteredOption(
+        key=key, defval=defval, doc=doc, validator=validator, cb=cb
+    )
+
+
+def is_type_factory(_type: type[Any]) -> Callable[[Any], None]:
+    """
+    Parameters
+    ----------
+    `_type` - a type to be compared against (e.g. type(x) == `_type`)
+    Returns
+    -------
+    validator - a function of a single argument x , which raises
+                ValueError if type(x) is not equal to `_type`
+    """
+
+    def inner(x) -> None:
+        if type(x) != _type:
+            raise ValueError(f"Value must have type '{_type}'")
+
+    return inner
+
+
+def is_instance_factory(_type) -> Callable[[Any], None]:
+    """
+    Parameters
+    ----------
+    `_type` - the type to be checked against
+    Returns
+    -------
+    validator - a function of a single argument x , which raises
+                ValueError if x is not an instance of `_type`
+    """
+    if isinstance(_type, (tuple, list)):
+        _type = tuple(_type)
+        type_repr = "|".join(map(str, _type))
+    else:
+        type_repr = f"'{_type}'"
+
+    def inner(x) -> None:
+        if not isinstance(x, _type):
+            raise ValueError(f"Value must be an instance of {type_repr}")
+
+    return inner
+
+
+def is_one_of_factory(legal_values) -> Callable[[Any], None]:
+
+    callables = [c for c in legal_values if callable(c)]
+    legal_values = [c for c in legal_values if not callable(c)]
+
+    def inner(x) -> None:
+        if x not in legal_values:
+
+            if not any(c(x) for c in callables):
+                uvals = [str(lval) for lval in legal_values]
+                pp_values = "|".join(uvals)
+                msg = f"Value must be one of {pp_values}"
+                if len(callables):
+                    msg += " or a callable"
+                raise ValueError(msg)
+
+    return inner
+
+
+def is_nonnegative_int(value: object) -> None:
+    """
+    Verify that value is None or a positive int.
+    Parameters
+    ----------
+    value : None or int
+            The `value` to be checked.
+    Raises
+    ------
+    ValueError
+        When the value is not None or is a negative integer
+    """
+    if value is None:
+        return
+
+    elif isinstance(value, int):
+        if value >= 0:
+            return
+
+    msg = "Value must be a nonnegative integer or None"
+    raise ValueError(msg)
+
+
+# common type validators, for convenience
+# usage: register_option(... , validator = is_int)
+is_int = is_type_factory(int)
+is_bool = is_type_factory(bool)
+is_float = is_type_factory(float)
+is_str = is_type_factory(str)
+is_text = is_instance_factory((str, bytes))
+
+
+def is_callable(obj) -> bool:
+    """
+    Parameters
+    ----------
+    `obj` - the object to be checked
+    Returns
+    -------
+    validator - returns True if object is callable
+        raises ValueError otherwise.
+    """
+    if not callable(obj):
+        raise ValueError("Value must be a callable")
+    return True
+
+
+register_option("plot.font.color", "red", validator=is_str)
+register_option("plot.scatter.point_size", 10, validator=is_int)
+register_option(
+    "metrics.default",
+    [mtr.bias, mtr.rmse, mtr.urmse, mtr.mae, mtr.cc, mtr.si, mtr.r2],
+    doc="Default metrics to be used in skill tables if specific metrics are not described.",
+)

--- a/fmskill/settings.py
+++ b/fmskill/settings.py
@@ -30,7 +30,7 @@ Implementation
 
 """
 import re
-from typing import Any, Callable, Iterable, NamedTuple, Optional, Dict
+from typing import Any, Callable, Iterable, List, NamedTuple, Optional, Dict, Tuple
 import warnings
 import fmskill.metrics as mtr
 
@@ -199,7 +199,7 @@ class DictWrapper:
         return list(self.d.keys())
 
 
-def _select_options(pat: str) -> list[str]:
+def _select_options(pat: str) -> List[str]:
     """
     returns a list of keys matching `pat`
     if pat=="all", returns all registered options
@@ -216,7 +216,7 @@ def _select_options(pat: str) -> list[str]:
     return [k for k in keys if re.search(pat, k, re.I)]
 
 
-def _get_root(key: str) -> tuple[Dict[str, Any], str]:
+def _get_root(key: str) -> Tuple[Dict[str, Any], str]:
     path = key.split(".")
     cursor = _global_settings
     for p in path[:-1]:

--- a/fmskill/settings.py
+++ b/fmskill/settings.py
@@ -81,7 +81,7 @@ def _get_option(pat: str) -> Any:
     Parameters
     ----------
     pat : str
-        pattern of seeked option 
+        pattern of seeked option
 
     Returns
     -------
@@ -230,7 +230,7 @@ class OptionsContainer:
         try:
             v = object.__getattribute__(self, "d")[key]
         except KeyError as err:
-            raise OptionError("No such option") from err
+            raise OptionError(f"No such option: {key}") from err
         if isinstance(v, dict):
             return OptionsContainer(v, prefix)
         else:

--- a/fmskill/settings.py
+++ b/fmskill/settings.py
@@ -30,7 +30,7 @@ Implementation
 
 """
 import re
-from typing import Any, Callable, Iterable, NamedTuple
+from typing import Any, Callable, Iterable, NamedTuple, Union
 import warnings
 import fmskill.metrics as mtr
 
@@ -39,8 +39,8 @@ class RegisteredOption(NamedTuple):
     key: str
     defval: object
     doc: str
-    validator: Callable[[object], Any] | None
-    cb: Callable[[str], Any] | None
+    validator: Union[Callable[[object], Any], None]
+    cb: Union[Callable[[str], Any], None]
 
 
 # holds registered option metadata

--- a/fmskill/settings.py
+++ b/fmskill/settings.py
@@ -76,6 +76,18 @@ def _get_single_key(pat: str) -> str:
 
 
 def _get_option(pat: str) -> Any:
+    """Get value of a single option matching a pattern
+
+    Parameters
+    ----------
+    pat : str
+        pattern of seeked option 
+
+    Returns
+    -------
+    Any
+        value of matched option
+    """
     key = _get_single_key(pat)
 
     # walk the nested dict
@@ -84,9 +96,25 @@ def _get_option(pat: str) -> Any:
 
 
 def _set_option(*args, **kwargs) -> None:
+    """Set the value of one or more options
+
+    Examples
+    --------
+    >>> fmskill.set_option("plot.scatter.point_size", 4)
+    >>> fmskill.set_option({"plot.scatter.point_size": 4})
+    """
     # must at least 1 arg deal with constraints later
+
+    if len(args) == 1 and isinstance(args[0], dict):
+        # accept a dictonary of options
+        d = args[0]
+        args = []
+        for k, v in d.items():
+            args = args + [k, v]
+
     nargs = len(args)
     if not nargs or nargs % 2 != 0:
+        print(f"Input was args={args}, kwargs={kwargs}")
         raise ValueError("Must provide an even number of non-keyword arguments")
 
     # default to false
@@ -113,6 +141,14 @@ def _set_option(*args, **kwargs) -> None:
         #             o.cb(key)
         #     else:
         #         o.cb(key)
+
+
+def _option_to_dict(pat: str = "") -> Dict:
+    keys = _select_options(pat)
+    d = dict()
+    for k in keys:
+        d[k] = _get_option(k)
+    return d
 
 
 def _describe_option_short(pat: str = "", _print_desc: bool = True) -> Optional[str]:
@@ -143,7 +179,8 @@ def _describe_option(pat: str = "", _print_desc: bool = True) -> Optional[str]:
     return s
 
 
-def _reset_option(pat: str, silent: bool = False) -> None:
+def _reset_option(pat: str = "", silent: bool = False) -> None:
+    """Reset one or more options (matching a pattern) to the default value"""
 
     keys = _select_options(pat)
 
@@ -198,6 +235,14 @@ class OptionsContainer:
             return OptionsContainer(v, prefix)
         else:
             return _get_option(prefix)
+
+    def to_dict(self) -> Dict:
+        """Return options as dictionary with full-name keys"""
+        return _option_to_dict(self.prefix)
+
+    # def search(self, pat: str = "") -> List[str]:
+    #     keys = _select_options(f"{self.prefix}*{pat}")
+    #     return list(keys)
 
     def __repr__(self) -> str:
         return _describe_option_short(self.prefix, False)
@@ -260,9 +305,9 @@ def _build_option_description(k: str) -> str:
 
 
 # temporary disabled
-# get_option = _get_option
-# set_option = _set_option
-# reset_option = _reset_option
+get_option = _get_option
+set_option = _set_option
+reset_option = _reset_option
 # describe_option = _describe_option
 options = OptionsContainer(_global_settings)
 

--- a/fmskill/settings.py
+++ b/fmskill/settings.py
@@ -30,7 +30,17 @@ Implementation
 
 """
 import re
-from typing import Any, Callable, Iterable, List, NamedTuple, Optional, Dict, Tuple
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Dict,
+    Tuple,
+    Type,
+)
 import warnings
 import fmskill.metrics as mtr
 
@@ -330,7 +340,7 @@ def register_option(
     )
 
 
-def is_type_factory(_type: type[Any]) -> Callable[[Any], None]:
+def is_type_factory(_type: Type[Any]) -> Callable[[Any], None]:
     """
     Parameters
     ----------

--- a/fmskill/settings.py
+++ b/fmskill/settings.py
@@ -259,6 +259,11 @@ def _build_option_description(k: str) -> str:
     return s
 
 
+# temporary disabled
+# get_option = _get_option
+# set_option = _set_option
+# reset_option = _reset_option
+# describe_option = _describe_option
 options = OptionsContainer(_global_settings)
 
 

--- a/fmskill/settings.py
+++ b/fmskill/settings.py
@@ -42,6 +42,8 @@ from typing import (
     Type,
 )
 
+import numpy as np
+
 
 class RegisteredOption(NamedTuple):
     key: str
@@ -452,3 +454,25 @@ def is_callable(obj) -> bool:
     if not callable(obj):
         raise ValueError("Value must be a callable")
     return True
+
+def is_positive(value: object) -> None:
+    if np.isreal(value) and value > 0:
+        return
+    raise ValueError("Value must be a number greater than 0")
+
+
+def is_nonnegative(value: object) -> None:
+    if np.isreal(value) and value >= 0:
+        return
+    raise ValueError("Value must be a non-negative number")
+
+
+def is_between_0_and_1(value: object) -> None:
+    if np.isreal(value) and value >= 0 and value <= 1:
+        return
+    raise ValueError("Value must be a number between 0 and 1")
+
+def is_dict(value: object) -> None:
+    if isinstance(value, dict):
+        return
+    raise ValueError("Value must be a dictionary")

--- a/fmskill/settings.py
+++ b/fmskill/settings.py
@@ -30,7 +30,7 @@ Implementation
 
 """
 import re
-from typing import Any, Callable, Iterable, NamedTuple, Union
+from typing import Any, Callable, Iterable, NamedTuple, Optional
 import warnings
 import fmskill.metrics as mtr
 
@@ -39,8 +39,8 @@ class RegisteredOption(NamedTuple):
     key: str
     defval: object
     doc: str
-    validator: Union[Callable[[object], Any], None]
-    cb: Union[Callable[[str], Any], None]
+    validator: Optional[Callable[[object], Any]]
+    cb: Optional[Callable[[str], Any]]
 
 
 # holds registered option metadata
@@ -107,7 +107,7 @@ def _set_option(*args, **kwargs) -> None:
                 o.cb(key)
 
 
-def _describe_option_short(pat: str = "", _print_desc: bool = True) -> str | None:
+def _describe_option_short(pat: str = "", _print_desc: bool = True) -> Optional[str]:
 
     keys = _select_options(pat)
     if len(keys) == 0:
@@ -121,7 +121,7 @@ def _describe_option_short(pat: str = "", _print_desc: bool = True) -> str | Non
     return s
 
 
-def _describe_option(pat: str = "", _print_desc: bool = True) -> str | None:
+def _describe_option(pat: str = "", _print_desc: bool = True) -> Optional[str]:
 
     keys = _select_options(pat)
     if len(keys) == 0:
@@ -262,8 +262,8 @@ def register_option(
     key: str,
     defval: object,
     doc: str = "",
-    validator: Callable[[object], Any] | None = None,
-    cb: Callable[[str], Any] | None = None,
+    validator: Optional[Callable[[object], Any]] = None,
+    cb: Optional[Callable[[str], Any]] = None,
 ) -> None:
     """
     Register an option in the package-wide pandas config object

--- a/fmskill/settings.py
+++ b/fmskill/settings.py
@@ -30,7 +30,7 @@ Implementation
 
 """
 import re
-from typing import Any, Callable, Iterable, NamedTuple, Optional
+from typing import Any, Callable, Iterable, NamedTuple, Optional, Dict
 import warnings
 import fmskill.metrics as mtr
 
@@ -44,10 +44,10 @@ class RegisteredOption(NamedTuple):
 
 
 # holds registered option metadata
-_registered_options: dict[str, RegisteredOption] = {}
+_registered_options: Dict[str, RegisteredOption] = {}
 
 # holds the current values for registered options
-_global_settings: dict[str, Any] = {}
+_global_settings: Dict[str, Any] = {}
 
 
 class OptionError(AttributeError, KeyError):
@@ -161,7 +161,7 @@ def get_default_val(pat: str):
 class DictWrapper:
     """provide attribute-style access to a nested dict"""
 
-    def __init__(self, d: dict[str, Any], prefix: str = "") -> None:
+    def __init__(self, d: Dict[str, Any], prefix: str = "") -> None:
         object.__setattr__(self, "d", d)
         object.__setattr__(self, "prefix", prefix)
 
@@ -216,7 +216,7 @@ def _select_options(pat: str) -> list[str]:
     return [k for k in keys if re.search(pat, k, re.I)]
 
 
-def _get_root(key: str) -> tuple[dict[str, Any], str]:
+def _get_root(key: str) -> tuple[Dict[str, Any], str]:
     path = key.split(".")
     cursor = _global_settings
     for p in path[:-1]:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     install_requires=[
         "numpy",
         "pandas",
-        "mikeio >= 1.2, <1.3",
+        "mikeio >= 1.2",
         "matplotlib",
         "xarray",
         "markdown",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     install_requires=[
         "numpy",
         "pandas",
-        "mikeio >= 1.2",
+        "mikeio >= 1.2, <1.3",
         "matplotlib",
         "xarray",
         "markdown",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,9 @@
+import fmskill
+import fmskill.settings as settings
+
+
+def test_options():
+    o = fmskill.options
+    assert isinstance(o, settings.OptionsContainer)
+    assert isinstance(o.plot, settings.OptionsContainer)
+    assert isinstance(o.metrics, settings.OptionsContainer)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,3 +1,5 @@
+import pytest
+
 import fmskill
 import fmskill.settings as settings
 
@@ -16,19 +18,25 @@ def test_options_repr():
     assert "metrics.list" in repr(o.metrics)
 
 
-def test_options_get_options():   
+def test_options_get_options():
     o = fmskill.options
     assert o.plot.scatter.points.size == 20
     assert fmskill.get_option("plot.scatter.points.size") == 20
-    
+
     # does not need to be complete, just unique
     assert fmskill.get_option("scatter.points.size") == 20
+
+    with pytest.raises(settings.OptionError):
+        # there are many color options
+        assert fmskill.get_option("color")
+
 
 def test_options_to_dict():
     o = fmskill.options
     d = o.to_dict()
     assert d["plot.scatter.points.size"] == 20
     assert d["metrics.list"][0] == o.metrics.list[0]
+
 
 def test_options_set_options():
     o = fmskill.options
@@ -39,7 +47,8 @@ def test_options_set_options():
 
     fmskill.set_option("plot.scatter.points.size", 200)
     assert o.plot.scatter.points.size == 200
-    
+
+
 def test_options_reset_options():
     o = fmskill.options
     o.plot.scatter.points.size = 300

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -31,6 +31,21 @@ def test_options_get_options():
         assert fmskill.get_option("color")
 
 
+def test_options_get_options_dict():
+    o = fmskill.options
+    d0 = o.plot.scatter.quantiles.kwargs
+    # dict is a special case, it cannot be accessed as an attribute
+    # without some additional code
+    assert not isinstance(d0, dict)
+    assert isinstance(d0, settings.OptionsContainer)
+    d1 = list(d0.to_dict().values())[0]
+    assert isinstance(d1, dict)
+    
+    # this is the way to get the dict
+    d = settings.get_option("plot.scatter.quantiles.kwargs")
+    assert isinstance(d, dict)
+
+
 def test_options_to_dict():
     o = fmskill.options
     d = o.to_dict()
@@ -48,6 +63,12 @@ def test_options_set_options():
     fmskill.set_option("plot.scatter.points.size", 200)
     assert o.plot.scatter.points.size == 200
 
+    # validation fails
+    with pytest.raises(ValueError):
+        fmskill.set_option("plot.scatter.points.size", "200")
+        fmskill.set_option("plot.scatter.points.size", -1)
+
+
 
 def test_options_reset_options():
     o = fmskill.options
@@ -55,3 +76,16 @@ def test_options_reset_options():
     assert o.plot.scatter.points.size == 300
     fmskill.reset_option("plot.scatter.points.size")
     assert o.plot.scatter.points.size == 20
+
+
+def test_options_register_option():
+    with pytest.raises(settings.OptionError):
+        # non-existing option
+        assert fmskill.get_option("plot.scatter.points.size2")
+    
+    settings.register_option("plot.scatter.points.size2", 200, "test")
+    assert fmskill.get_option("plot.scatter.points.size2") == 200
+    fmskill.set_option("plot.scatter.points.size2", 300)
+    assert fmskill.get_option("plot.scatter.points.size2") == 300
+    fmskill.reset_option("plot.scatter.points.size2")
+    assert fmskill.get_option("plot.scatter.points.size2") == 200

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -7,3 +7,42 @@ def test_options():
     assert isinstance(o, settings.OptionsContainer)
     assert isinstance(o.plot, settings.OptionsContainer)
     assert isinstance(o.metrics, settings.OptionsContainer)
+
+
+def test_options_repr():
+    o = fmskill.options
+    assert "metrics.list" in repr(o)
+    assert "plot.scatter.points.size" in repr(o.plot)
+    assert "metrics.list" in repr(o.metrics)
+
+
+def test_options_get_options():   
+    o = fmskill.options
+    assert o.plot.scatter.points.size == 20
+    assert fmskill.get_option("plot.scatter.points.size") == 20
+    
+    # does not need to be complete, just unique
+    assert fmskill.get_option("scatter.points.size") == 20
+
+def test_options_to_dict():
+    o = fmskill.options
+    d = o.to_dict()
+    assert d["plot.scatter.points.size"] == 20
+    assert d["metrics.list"][0] == o.metrics.list[0]
+
+def test_options_set_options():
+    o = fmskill.options
+    o.plot.scatter.points.size = 300
+    assert o.plot.scatter.points.size == 300
+    o.plot.scatter.points.size = 100
+    assert o.plot.scatter.points.size == 100
+
+    fmskill.set_option("plot.scatter.points.size", 200)
+    assert o.plot.scatter.points.size == 200
+    
+def test_options_reset_options():
+    o = fmskill.options
+    o.plot.scatter.points.size = 300
+    assert o.plot.scatter.points.size == 300
+    fmskill.reset_option("plot.scatter.points.size")
+    assert o.plot.scatter.points.size == 20


### PR DESCRIPTION
fmskill.options with methods for:  

* registering fmskill options (including default value, decription and validator)
* referencing options using dot-notation
* restoring default values

![image](https://user-images.githubusercontent.com/34088801/211759434-3a375507-663b-45d1-8641-ddca613fd4f9.png)
