### PR TITLE
return AX in scatter

### DIFF
--- a/fmskill/comparison.py
+++ b/fmskill/comparison.py
@@ -1006,7 +1006,7 @@ class BaseComparer:
             skill_df = None
             units = None
 
-        scatter(
+        ax=scatter(
             x=x,
             y=y,
             bins=bins,
@@ -1028,6 +1028,7 @@ class BaseComparer:
             nbins=nbins,
             **kwargs,
         )
+        return ax
 
     def taylor(
         self,

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -238,8 +238,8 @@ def scatter(
     reglabel = f"Fit: y={slope:.2f}x{sign}{intercept:.2f}"
 
     if backend == "matplotlib":
-
-        plt.figure(figsize=figsize)
+        _,ax=plt.subplots(figsize=figsize)
+        #plt.figure(figsize=figsize)
         plt.plot(
             [xlim[0], xlim[1]],
             [xlim[0], xlim[1]],
@@ -305,6 +305,7 @@ def scatter(
         # Add skill table
         if skill_df != None:
             _plot_summary_table(skill_df, units, max_cbar=max_cbar)
+        return ax
 
     elif backend == "plotly":  # pragma: no cover
         import plotly.graph_objects as go


### PR DESCRIPTION
I am returning the axes object in scatter plot (just as is done in the timeseries) since sometimes people want to do things (ax.add_patches or ax.set_some_parameter or rename the ticks, etc) and it was not possible in the scatter plot.

In timeseries is done here

https://github.com/DHI/fmskill/blob/2c0f988c1c2ab2e3501e4b35b9a4ff5e34a0c435/fmskill/comparison.py#L1592-L1636