### PR TITLE
add warning scatter plot

### DIFF
--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -152,13 +152,14 @@ def scatter(
 
     x_sample = x
     y_sample = y
-
+    sample_warning=False
     if show_points is None:
         # If nothing given, and more than 50k points, 50k sample will be shown
         if len(x) < 5e4:
             show_points = True
         else:
             show_points = 50000
+            sample_warning=True
     if type(show_points) == float:
         if show_points < 0 or show_points > 1:
             raise ValueError(" `show_points` fraction must be in [0,1]")
@@ -169,17 +170,24 @@ def scatter(
             )
             x_sample = x[ran_index]
             y_sample = y[ran_index]
+            if len(x_sample)<len(x):
+                sample_warning=True
     # if show_points is an int
     elif type(show_points) == int:
         np.random.seed(20)
         ran_index = np.random.choice(range(len(x)), show_points, replace=False)
         x_sample = x[ran_index]
         y_sample = y[ran_index]
+        if len(x_sample)<len(x):
+            sample_warning=True
     elif type(show_points) == bool:
         pass
     else:
         raise TypeError(" `show_points` must be either bool, int or float")
-
+    if sample_warning:
+        warnings.warn(
+            message=f'Showing only {len(x_sample)} points in plot. If all scatter points wanted in plot, use `show_points=True`',
+            stacklevel=2)
     xmin, xmax = x.min(), x.max()
     ymin, ymax = y.min(), y.max()
     xymin = min([xmin, ymin])


### PR DESCRIPTION
Hi, I added a warning the following reasons
* Usually when plotting a scatter plot with points, having 50k points is enough, and for larger datasets by default a sample of the dataset is plotted (as this is faster than plotting the complete dataset)
* In most cases this is ok, but sometimes the user wants to see all points to identify the possible outliers, this was already possible with `show_points=True` , but sometimes the user (aka myself) forget about this.
* I rarely have more than 50k points when comparing model/measurements, but when I do, I want to be reminded that the plot is just using a sample, so I added a warning that, if a sample of the total set is being plotted (despite the statistics being calculated on the total data set), will remind the user of this
* For smaller datasets (<50k points) the total set is plotted and the warning is not triggered. Also if `show_points=True` or  `show_points=1.0` the warning is not triggered. 