### PR TITLE
Style limits qq

### DIFF
--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -193,11 +193,7 @@ def scatter(
     xymin = min([xmin, ymin])
     xymax = max([xmax, ymax])
 
-    if xlim is None:
-        xlim = [xymin, xymax]
 
-    if ylim is None:
-        ylim = [xymin, xymax]
 
     if quantiles is None:
         if len(x) >= 3000:
@@ -226,6 +222,12 @@ def scatter(
         else:
             nbins_hist = int((xmax - xmin) / binsize_aux)
     # Remove previous piece of code when nbins and bin_size are deprecated.
+
+    if xlim is None:
+        xlim = [xymin - binsize, xymax+ binsize]
+
+    if ylim is None:
+        ylim = [xymin - binsize, xymax+ binsize]
 
     if type(quantiles) == int:
         xq = np.quantile(x, q=np.linspace(0, 1, num=quantiles))
@@ -275,8 +277,8 @@ def scatter(
         _,ax=plt.subplots(figsize=figsize)
         #plt.figure(figsize=figsize)
         plt.plot(
-            [xlim[0]- binsize, xlim[1]+ binsize],
-            [xlim[0]- binsize, xlim[1]+ binsize],
+            [xlim[0], xlim[1]],
+            [xlim[0], xlim[1]],
             label=options.plot.scatter.oneone_line.label,
             c=options.plot.scatter.oneone_line.color,
             zorder=3,
@@ -323,8 +325,8 @@ def scatter(
         plt.xlabel(xlabel)
         plt.ylabel(ylabel)
         plt.axis("square")
-        plt.xlim([xlim[0] - binsize, xlim[1] + binsize])
-        plt.ylim([ylim[0] - binsize, ylim[1] + binsize])
+        plt.xlim([xlim[0], xlim[1]])
+        plt.ylim([ylim[0], ylim[1]])
         plt.minorticks_on()
         plt.grid(which="both", axis="both", linewidth="0.2", color="k",alpha=0.6)
         max_cbar = None

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -234,7 +234,8 @@ def scatter(
         # if not an int nor None, it must be a squence of floats
         xq = np.quantile(x, q=quantiles)
         yq = np.quantile(y, q=quantiles)
-
+        
+        
     if show_hist:
         # if histogram is wanted (explicit non-default flag) then density is off
         if show_density == True:
@@ -256,9 +257,10 @@ def scatter(
         z = _scatter_density(x_sample, y_sample, binsize=binsize)
         idx = z.argsort()
         # Sort data by colormaps
-        x_sample, y_sample, z = x_sample[idx], y_sample[idx], z[idx]
+        x_sample, y_sample, z = x_sample[idx], y_sample[idx], z[idx]        
         # scale Z by sample size
-        z = z * len(x) / len(x_sample)
+        z = z * len(x) / len(x_sample)     
+ 
 
     # linear fit
     slope, intercept = _linear_regression(obs=x, model=y, reg_method=reg_method)
@@ -273,8 +275,8 @@ def scatter(
         _,ax=plt.subplots(figsize=figsize)
         #plt.figure(figsize=figsize)
         plt.plot(
-            [xlim[0], xlim[1]],
-            [xlim[0], xlim[1]],
+            [xlim[0]- binsize, xlim[1]+ binsize],
+            [xlim[0]- binsize, xlim[1]+ binsize],
             label=options.plot.scatter.oneone_line.label,
             c=options.plot.scatter.oneone_line.color,
             zorder=3,
@@ -321,8 +323,8 @@ def scatter(
         plt.xlabel(xlabel)
         plt.ylabel(ylabel)
         plt.axis("square")
-        plt.xlim(xlim)
-        plt.ylim(ylim)
+        plt.xlim([xlim[0] - binsize, xlim[1] + binsize])
+        plt.ylim([ylim[0] - binsize, ylim[1] + binsize])
         plt.minorticks_on()
         plt.grid(which="both", axis="both", linewidth="0.2", color="k",alpha=0.6)
         max_cbar = None
@@ -532,8 +534,8 @@ def _scatter_density(x, y, binsize: float = 0.1, method: str = "linear"):
     """
 
     # Make linear-grid for interpolation
-    minxy = min(min(x), min(y))
-    maxxy = max(max(x), max(y))
+    minxy = min(min(x), min(y))-binsize
+    maxxy = max(max(x), max(y))+binsize
     # Center points of the bins
     cxy = np.arange(minxy, maxxy, binsize)
 

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -236,7 +236,7 @@ def scatter(
         # if not an int nor None, it must be a squence of floats
         xq = np.quantile(x, q=quantiles)
         yq = np.quantile(y, q=quantiles)
-        
+    x_trend= np.array([xlim[0],xlim[1]])   
         
     if show_hist:
         # if histogram is wanted (explicit non-default flag) then density is off
@@ -312,8 +312,8 @@ def scatter(
             **settings.get_option("plot.scatter.quantiles.kwargs"),
         )
         plt.plot(
-            x,
-            intercept + slope * x,
+            x_trend,
+            intercept + slope * x_trend,
             **settings.get_option("plot.scatter.reg_line.kwargs"),
             label=reglabel,
             zorder=2,

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -534,11 +534,10 @@ def _scatter_density(x, y, binsize: float = 0.1, method: str = "linear"):
     """
 
     # Make linear-grid for interpolation
-    minxy = min(min(x), min(y))-binsize
-    maxxy = max(max(x), max(y))+binsize
+    minxy = min(min(x), min(y))-binsize/2
+    maxxy = max(max(x), max(y))+binsize/2
     # Center points of the bins
     cxy = np.arange(minxy, maxxy, binsize)
-
     # Edges of the bins
     exy = np.arange(minxy - binsize * 0.5, maxxy + binsize * 0.5, binsize)
 


### PR DESCRIPTION
Hi, two small changes
* First, I added one more bin on the Scatter plot on both edges, because before it was difficult to see the first/last quantiles plot. Actually since Xlim was = to max (x), the final point was cut in half. See fig. before/after.

Before
---
![image](https://user-images.githubusercontent.com/97288080/231167497-72a085eb-fdbc-4b7a-96f4-68738203cdf1.png)

Now
---
![image](https://user-images.githubusercontent.com/97288080/231167332-d79da6e0-6183-4faf-b7fd-c227c099a0e4.png)


* Second and last, the way the scatter density was being calculated was missing half a bin at both edges, which eliminated the extreme points (they were present in the QQ but not in the scatter). This only happened when `show_density=True`. If false, all points where there.

See before:
---
`show_density=True`
![image](https://user-images.githubusercontent.com/97288080/231168204-9a854a2c-c044-4127-ac09-4aaa043e0295.png)
`show_density=False`
![image](https://user-images.githubusercontent.com/97288080/231168251-48f9e05f-3dd7-4145-904d-ec899d160c1e.png)

Now it shows all the points on the extremes.

See now
---
![image](https://user-images.githubusercontent.com/97288080/231168505-7269335f-a1ba-4c2d-9f53-1e7b71e3f583.png)
