### PR TITLE
add degree to short names

### DIFF
--- a/fmskill/observation.py
+++ b/fmskill/observation.py
@@ -552,6 +552,7 @@ def unit_display_name(name: str) -> str:
         .replace(" per ", "/")
         .replace("second", "s")
         .replace("sec", "s")
+        .replace("degree", "°")
     )
 
     return res


### PR DESCRIPTION
Hi, i just added the mapping of `degree` to `°` to the short names function in the units (where `metre` is changed to `m` and seconds to `s` and `per` to `/` ), because degree is a long word an nobody wants to see

* Direction [degree]

but everyone likes

* Direction [°]