### PR TITLE
fix small density-bug and added test

### DIFF
--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -256,7 +256,7 @@ def scatter(
                 "if `show_density=True` then `show_hist` must be either `False` or `None`"
             )
         # calculate density data
-        z = _scatter_density(x_sample, y_sample, binsize=binsize)
+        z = __scatter_density(x_sample, y_sample, binsize=binsize)
         idx = z.argsort()
         # Sort data by colormaps
         x_sample, y_sample, z = x_sample[idx], y_sample[idx], z[idx]        
@@ -515,8 +515,8 @@ def taylor_diagram(
     fig.suptitle(title, size="x-large")
 
 
-def _scatter_density(x, y, binsize: float = 0.1, method: str = "linear"):
-    """Interpolates scatter data on a 2D histogram (gridded) based on data density.
+def __hist2d(x, y, binsize):
+    """Calculates 2D histogram (gridded) of data.
 
     Parameters
     ----------
@@ -525,16 +525,17 @@ def _scatter_density(x, y, binsize: float = 0.1, method: str = "linear"):
     y: np.array
         Y values e.g observation values, must be same length as x
     binsize: float, optional
-        2D grid resolution, by default = 0.1
-    method: str, optional
-        Scipy griddata interpolation method, by default 'linear'
+        2D histogram (bin) resolution, by default = 0.1
 
     Returns
     ----------
-    Z_grid: np.array
-        Array with the colors based on histogram density
+    histodata: np.array
+        2D-histogram data
+    cxy: np.array
+        Center points of the histogram bins
+    exy: np.array
+        Edges of the histogram bins
     """
-
     # Make linear-grid for interpolation
     minxy = min(min(x), min(y))-binsize
     maxxy = max(max(x), max(y))+binsize
@@ -549,6 +550,30 @@ def _scatter_density(x, y, binsize: float = 0.1, method: str = "linear"):
 
     # Calculate 2D histogram
     histodata, exh, eyh = np.histogram2d(x, y, [exy, exy])
+
+    return histodata,cxy,exy
+
+def __scatter_density(x, y, binsize: float = 0.1, method: str = "linear"):
+    """Interpolates scatter data on a 2D histogram (gridded) based on data density.
+
+    Parameters
+    ----------
+    x: np.array
+        X values e.g model values, must be same length as y
+    y: np.array
+        Y values e.g observation values, must be same length as x
+    binsize: float, optional
+        2D histogram (bin) resolution, by default = 0.1
+    method: str, optional
+        Scipy griddata interpolation method, by default 'linear'
+
+    Returns
+    ----------
+    Z_grid: np.array
+        Array with the colors based on histogram density
+    """
+
+    histodata,cxy,exy=__hist2d(x, y, binsize)
 
     # Histogram values
     hist = []

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -134,7 +134,7 @@ def scatter(
         user default units to override default units, eg 'metre', by default None
     kwargs
     """
-    if show_hist == None and show_density == None:
+    if show_hist is None and show_density is None:
         # Default: points density
         show_density = True
 
@@ -240,7 +240,7 @@ def scatter(
 
     if show_hist:
         # if histogram is wanted (explicit non-default flag) then density is off
-        if show_density == True:
+        if show_density is True:
             raise TypeError(
                 "if `show_hist=True` then `show_density` must be either `False` or `None`"
             )
@@ -251,7 +251,7 @@ def scatter(
                 "if `show_density=True` then bins must be either float or int"
             )
         # if point density is wanted, then 2D histogram is not shown
-        if show_hist == True:
+        if show_hist is True:
             raise TypeError(
                 "if `show_density=True` then `show_hist` must be either `False` or `None`"
             )
@@ -337,7 +337,7 @@ def scatter(
 
         plt.title(title)
         # Add skill table
-        if skill_df != None:
+        if skill_df is not None:
             _plot_summary_table(skill_df, units, max_cbar=max_cbar)
         return ax
 
@@ -548,7 +548,7 @@ def __hist2d(x, y, binsize):
         exy = np.arange(minxy - binsize * 0.5, maxxy + binsize, binsize)
 
     # Calculate 2D histogram
-    histodata, exh, _ = np.histogram2d(x, y, [exy, exy])
+    histodata, _, _ = np.histogram2d(x, y, [exy, exy])
 
     # Histogram values
     hist = []
@@ -620,7 +620,7 @@ def _plot_summary_table(skill_df, units, max_cbar):
 
     text_ = "\n".join(lines)
 
-    if max_cbar == None:
+    if max_cbar is None:
         x = 0.93
     elif max_cbar < 1e3:
         x = 0.99

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -549,7 +549,7 @@ def __hist2d(x, y, binsize):
         exy = np.arange(minxy - binsize * 0.5, maxxy + binsize, binsize)
 
     # Calculate 2D histogram
-    histodata, exh, eyh = np.histogram2d(x, y, [exy, exy])
+    histodata, exh, _ = np.histogram2d(x, y, [exy, exy])
 
     # Histogram values
     hist = []
@@ -557,7 +557,7 @@ def __hist2d(x, y, binsize):
         for i in range(len(cxy)):
             hist.append(histodata[i, j])
 
-    return hist,cxy,exy
+    return hist,cxy
 
 def __scatter_density(x, y, binsize: float = 0.1, method: str = "linear"):
     """Interpolates scatter data on a 2D histogram (gridded) based on data density.
@@ -579,7 +579,7 @@ def __scatter_density(x, y, binsize: float = 0.1, method: str = "linear"):
         Array with the colors based on histogram density
     """
 
-    hist,cxy,exy=__hist2d(x, y, binsize)
+    hist,cxy=__hist2d(x, y, binsize)
 
     # Grid-data
     xg, yg = np.meshgrid(cxy, cxy)

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -56,6 +56,7 @@ register_option(
 # register_option("plot.scatter.table.show", False, validator=settings.is_bool)
 register_option("plot.scatter.legend.fontsize", 12, validator=settings.is_positive)
 
+
 def scatter(
     x,
     y,
@@ -152,14 +153,14 @@ def scatter(
 
     x_sample = x
     y_sample = y
-    sample_warning=False
+    sample_warning = False
     if show_points is None:
         # If nothing given, and more than 50k points, 50k sample will be shown
         if len(x) < 5e4:
             show_points = True
         else:
             show_points = 50000
-            sample_warning=True
+            sample_warning = True
     if type(show_points) == float:
         if show_points < 0 or show_points > 1:
             raise ValueError(" `show_points` fraction must be in [0,1]")
@@ -170,30 +171,29 @@ def scatter(
             )
             x_sample = x[ran_index]
             y_sample = y[ran_index]
-            if len(x_sample)<len(x):
-                sample_warning=True
+            if len(x_sample) < len(x):
+                sample_warning = True
     # if show_points is an int
     elif type(show_points) == int:
         np.random.seed(20)
         ran_index = np.random.choice(range(len(x)), show_points, replace=False)
         x_sample = x[ran_index]
         y_sample = y[ran_index]
-        if len(x_sample)<len(x):
-            sample_warning=True
+        if len(x_sample) < len(x):
+            sample_warning = True
     elif type(show_points) == bool:
         pass
     else:
         raise TypeError(" `show_points` must be either bool, int or float")
     if sample_warning:
         warnings.warn(
-            message=f'Showing only {len(x_sample)} points in plot. If all scatter points wanted in plot, use `show_points=True`',
-            stacklevel=2)
+            message=f"Showing only {len(x_sample)} points in plot. If all scatter points wanted in plot, use `show_points=True`",
+            stacklevel=2,
+        )
     xmin, xmax = x.min(), x.max()
     ymin, ymax = y.min(), y.max()
     xymin = min([xmin, ymin])
     xymax = max([xmax, ymax])
-
-
 
     if quantiles is None:
         if len(x) >= 3000:
@@ -224,10 +224,10 @@ def scatter(
     # Remove previous piece of code when nbins and bin_size are deprecated.
 
     if xlim is None:
-        xlim = [xymin - binsize, xymax+ binsize]
+        xlim = [xymin - binsize, xymax + binsize]
 
     if ylim is None:
-        ylim = [xymin - binsize, xymax+ binsize]
+        ylim = [xymin - binsize, xymax + binsize]
 
     if type(quantiles) == int:
         xq = np.quantile(x, q=np.linspace(0, 1, num=quantiles))
@@ -236,8 +236,8 @@ def scatter(
         # if not an int nor None, it must be a squence of floats
         xq = np.quantile(x, q=quantiles)
         yq = np.quantile(y, q=quantiles)
-    x_trend= np.array([xlim[0],xlim[1]])   
-        
+    x_trend = np.array([xlim[0], xlim[1]])
+
     if show_hist:
         # if histogram is wanted (explicit non-default flag) then density is off
         if show_density == True:
@@ -259,10 +259,9 @@ def scatter(
         z = __scatter_density(x_sample, y_sample, binsize=binsize)
         idx = z.argsort()
         # Sort data by colormaps
-        x_sample, y_sample, z = x_sample[idx], y_sample[idx], z[idx]        
+        x_sample, y_sample, z = x_sample[idx], y_sample[idx], z[idx]
         # scale Z by sample size
-        z = z * len(x) / len(x_sample)     
- 
+        z = z * len(x) / len(x_sample)
 
     # linear fit
     slope, intercept = _linear_regression(obs=x, model=y, reg_method=reg_method)
@@ -274,8 +273,8 @@ def scatter(
     reglabel = f"Fit: y={slope:.2f}x{sign}{intercept:.2f}"
 
     if backend == "matplotlib":
-        _,ax=plt.subplots(figsize=figsize)
-        #plt.figure(figsize=figsize)
+        _, ax = plt.subplots(figsize=figsize)
+        # plt.figure(figsize=figsize)
         plt.plot(
             [xlim[0], xlim[1]],
             [xlim[0], xlim[1]],
@@ -328,7 +327,7 @@ def scatter(
         plt.xlim([xlim[0], xlim[1]])
         plt.ylim([ylim[0], ylim[1]])
         plt.minorticks_on()
-        plt.grid(which="both", axis="both", linewidth="0.2", color="k",alpha=0.6)
+        plt.grid(which="both", axis="both", linewidth="0.2", color="k", alpha=0.6)
         max_cbar = None
         if show_hist or (show_density and show_points):
             cbar = plt.colorbar(fraction=0.046, pad=0.04)
@@ -537,14 +536,14 @@ def __hist2d(x, y, binsize):
         Edges of the histogram bins
     """
     # Make linear-grid for interpolation
-    minxy = min(min(x), min(y))-binsize
-    maxxy = max(max(x), max(y))+binsize
+    minxy = min(min(x), min(y)) - binsize
+    maxxy = max(max(x), max(y)) + binsize
     # Center points of the bins
     cxy = np.arange(minxy, maxxy, binsize)
     # Edges of the bins
     exy = np.arange(minxy - binsize * 0.5, maxxy + binsize * 0.5, binsize)
-    if exy[-1]<=cxy[-1]:
-        #sometimes, given the bin size, the edges array ended before (left side) of the bins-center array
+    if exy[-1] <= cxy[-1]:
+        # sometimes, given the bin size, the edges array ended before (left side) of the bins-center array
         # in such case, and extra half-bin is added at the end
         exy = np.arange(minxy - binsize * 0.5, maxxy + binsize, binsize)
 
@@ -557,7 +556,8 @@ def __hist2d(x, y, binsize):
         for i in range(len(cxy)):
             hist.append(histodata[i, j])
 
-    return hist,cxy
+    return hist, cxy
+
 
 def __scatter_density(x, y, binsize: float = 0.1, method: str = "linear"):
     """Interpolates scatter data on a 2D histogram (gridded) based on data density.
@@ -579,7 +579,7 @@ def __scatter_density(x, y, binsize: float = 0.1, method: str = "linear"):
         Array with the colors based on histogram density
     """
 
-    hist,cxy=__hist2d(x, y, binsize)
+    hist, cxy = __hist2d(x, y, binsize)
 
     # Grid-data
     xg, yg = np.meshgrid(cxy, cxy)

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -551,7 +551,13 @@ def __hist2d(x, y, binsize):
     # Calculate 2D histogram
     histodata, exh, eyh = np.histogram2d(x, y, [exy, exy])
 
-    return histodata,cxy,exy
+    # Histogram values
+    hist = []
+    for j in range(len(cxy)):
+        for i in range(len(cxy)):
+            hist.append(histodata[i, j])
+
+    return hist,cxy,exy
 
 def __scatter_density(x, y, binsize: float = 0.1, method: str = "linear"):
     """Interpolates scatter data on a 2D histogram (gridded) based on data density.
@@ -573,13 +579,7 @@ def __scatter_density(x, y, binsize: float = 0.1, method: str = "linear"):
         Array with the colors based on histogram density
     """
 
-    histodata,cxy,exy=__hist2d(x, y, binsize)
-
-    # Histogram values
-    hist = []
-    for j in range(len(cxy)):
-        for i in range(len(cxy)):
-            hist.append(histodata[i, j])
+    hist,cxy,exy=__hist2d(x, y, binsize)
 
     # Grid-data
     xg, yg = np.meshgrid(cxy, cxy)

--- a/fmskill/plot.py
+++ b/fmskill/plot.py
@@ -536,12 +536,16 @@ def _scatter_density(x, y, binsize: float = 0.1, method: str = "linear"):
     """
 
     # Make linear-grid for interpolation
-    minxy = min(min(x), min(y))-binsize/2
-    maxxy = max(max(x), max(y))+binsize/2
+    minxy = min(min(x), min(y))-binsize
+    maxxy = max(max(x), max(y))+binsize
     # Center points of the bins
     cxy = np.arange(minxy, maxxy, binsize)
     # Edges of the bins
     exy = np.arange(minxy - binsize * 0.5, maxxy + binsize * 0.5, binsize)
+    if exy[-1]<=cxy[-1]:
+        #sometimes, given the bin size, the edges array ended before (left side) of the bins-center array
+        # in such case, and extra half-bin is added at the end
+        exy = np.arange(minxy - binsize * 0.5, maxxy + binsize, binsize)
 
     # Calculate 2D histogram
     histodata, exh, eyh = np.histogram2d(x, y, [exy, exy])

--- a/tests/test_multivariable_compare.py
+++ b/tests/test_multivariable_compare.py
@@ -134,6 +134,8 @@ def test_mv_mm_scatter(cc):
     cc.scatter(
         model="SW_1", variable="Wind_speed", observation="F16_wind", skill_table=True
     )
+    cc.scatter(model="SW_1", variable="Wind_speed", show_density=True,bins=19)
+    cc.scatter(model="SW_1", variable="Wind_speed", show_density=True,bins=21)
     assert True
     plt.close("all")
 


### PR DESCRIPTION
Hi, 
* I added an additional test for the scatter plot with density (actually extended a test by adding two lines, one with `bins=19` and another with `bins=21`)
* The reason behind this is that sometimes, as the way the 2d-histogram for scatter density plot was defined, given certain bin-sizes, the edges of the bins (2DHist bins) ended just before the center of the bins, which crashed the plots. This could easily be solved by changing the bin-size slightly or number of bins by one, but it is not ideal.
* So now, I check the last value of the center of the bins, and the last value of the edge of the bins, and if the latter is smaller than the former, I add an extra 1/2 bin, to make sure that the bin-edges fully cover the bins-center. This has no impact on the final result (plot), but avoids the error.